### PR TITLE
Add Deno Kv-powered catalog CMS 

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -5,6 +5,7 @@
     "@fartlabs/htx": "jsr:@fartlabs/htx@^0.0.10",
     "@fartlabs/jsonx": "jsr:@fartlabs/jsonx@^0.0.11",
     "@fartlabs/rtx": "jsr:@fartlabs/rtx@^0.0.15",
+    "@kitsonk/kv-toolbox": "jsr:@kitsonk/kv-toolbox@^0.30.0",
     "@orama/orama": "npm:@orama/orama@^3.1.13",
     "@std/http": "jsr:@std/http@^1.0.17"
   },

--- a/deno.json
+++ b/deno.json
@@ -7,7 +7,8 @@
     "@fartlabs/rtx": "jsr:@fartlabs/rtx@^0.0.15",
     "@kitsonk/kv-toolbox": "jsr:@kitsonk/kv-toolbox@^0.30.0",
     "@orama/orama": "npm:@orama/orama@^3.1.14",
-    "@std/http": "jsr:@std/http@^1.0.20"
+    "@std/http": "jsr:@std/http@^1.0.20",
+    "zod": "npm:zod@^4.1.11"
   },
   "tasks": {
     "start": "deno serve -A --env --unstable-kv main.ts",

--- a/deno.json
+++ b/deno.json
@@ -6,8 +6,8 @@
     "@fartlabs/jsonx": "jsr:@fartlabs/jsonx@^0.0.11",
     "@fartlabs/rtx": "jsr:@fartlabs/rtx@^0.0.15",
     "@kitsonk/kv-toolbox": "jsr:@kitsonk/kv-toolbox@^0.30.0",
-    "@orama/orama": "npm:@orama/orama@^3.1.13",
-    "@std/http": "jsr:@std/http@^1.0.17"
+    "@orama/orama": "npm:@orama/orama@^3.1.14",
+    "@std/http": "jsr:@std/http@^1.0.20"
   },
   "tasks": {
     "start": "deno serve -A --env --unstable-kv main.ts",

--- a/public/snf.css
+++ b/public/snf.css
@@ -259,6 +259,18 @@ footer {
   text-decoration: underline;
 }
 
+.footer-section {
+  display: flex;
+  flex-direction: column;
+}
+
+.footer-content {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 2rem;
+  align-items: start;
+}
+
 /* Buttons */
 button, .btn {
   display: inline-block;
@@ -291,10 +303,54 @@ form {
   margin-bottom: 2rem;
 }
 
+.form-group {
+  margin-bottom: 1.5rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: var(--dark-color);
+}
+
+.form-group input {
+  width: 100%;
+  padding: 0.75rem;
+  font-size: 1rem;
+  border: 2px solid var(--gray-300);
+  border-radius: 0.375rem;
+  transition: border-color 0.2s ease;
+  background-color: var(--white);
+}
+
+.form-group input:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(44, 90, 160, 0.1);
+}
+
+.form-actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--gray-200);
+  justify-content: space-between;
+  align-items: center;
+}
+
+.form-actions .btn-group {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.form-actions .btn-danger {
+  margin-left: auto;
+}
+
 input[type="search"],
-input[type="text"],
-input[type="email"],
-input[type="password"] {
+input[type="text"] {
   width: 100%;
   padding: 0.75rem;
   font-size: 1rem;
@@ -304,9 +360,7 @@ input[type="password"] {
 }
 
 input[type="search"]:focus,
-input[type="text"]:focus,
-input[type="email"]:focus,
-input[type="password"]:focus {
+input[type="text"]:focus {
   outline: none;
   border-color: var(--primary-color);
 }
@@ -445,6 +499,10 @@ li {
   flex-direction: column;
   gap: 1.5rem;
   align-items: flex-start;
+  text-decoration: none;
+  color: inherit;
+  width: 100%;
+  height: 100%;
 }
 
 .item-thumbnails {
@@ -519,7 +577,7 @@ li {
   line-height: 1.3;
 }
 
-.item-title:hover {
+.item-content:hover .item-title {
   color: var(--primary-dark);
   text-decoration: none;
 }
@@ -888,9 +946,93 @@ li {
   }
 }
 
-/* Utility Classes - Using Tailwind for basic utilities */
+/* Button Styles */
+.btn-danger {
+  background-color: #dc3545;
+  color: white;
+  border: 1px solid #dc3545;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  text-decoration: none;
+  display: inline-block;
+  font-weight: 600;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(220, 53, 69, 0.2);
+}
+
+.btn-danger:hover {
+  background-color: #c82333;
+  border-color: #bd2130;
+  color: white;
+  text-decoration: none;
+  box-shadow: 0 4px 8px rgba(220, 53, 69, 0.3);
+  transform: translateY(-1px);
+}
+
+.btn-danger:focus {
+  outline: 2px solid #dc3545;
+  outline-offset: 2px;
+}
+
+.btn-danger:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 2px rgba(220, 53, 69, 0.4);
+}
+
+.btn-primary {
+  background-color: var(--primary-color);
+  color: var(--white);
+  border: 1px solid var(--primary-color);
+}
+
+.btn-primary:hover {
+  background-color: var(--primary-dark);
+  border-color: var(--primary-dark);
+  color: var(--white);
+  text-decoration: none;
+}
+
+.btn-secondary {
+  background-color: var(--gray-100);
+  color: var(--gray-700);
+  border: 1px solid var(--gray-300);
+}
+
+.btn-secondary:hover {
+  background-color: var(--gray-200);
+  color: var(--gray-800);
+  text-decoration: none;
+}
+
+/* Utility Classes */
 .text-muted {
   color: var(--gray-600);
+}
+
+.text-center {
+  text-align: center;
+}
+
+.mb-0 {
+  margin-bottom: 0;
+}
+
+.mt-3 {
+  margin-top: 0.75rem;
+}
+
+.mt-4 {
+  margin-top: 1rem;
+}
+
+.list-unstyled {
+  list-style: none;
+  padding-left: 0;
+}
+
+.card-body {
+  padding: 1rem 0;
 }
 
 /* Focus States for Accessibility */

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,6 +3,7 @@ import { Get, Router } from "@fartlabs/rtx";
 import { IndexPageRoute } from "./routes/index.tsx";
 import { CatalogItemPageRoute } from "./routes/item.tsx";
 import { EditPageRoute } from "./routes/edit.tsx";
+import { ApiRoute } from "./routes/api.tsx";
 import { NotFoundRoute } from "./routes/not-found.tsx";
 
 function StaticRoute() {
@@ -21,6 +22,7 @@ export function App() {
       <IndexPageRoute />
       <EditPageRoute />
       <CatalogItemPageRoute />
+      <ApiRoute />
       <StaticRoute />
       <NotFoundRoute />
     </Router>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,8 @@
 import { serveDir } from "@std/http/file-server";
 import { Get, Router } from "@fartlabs/rtx";
 import { IndexPageRoute } from "./routes/index.tsx";
-import { CatalogItemPageRoute } from "./routes/catalog-item/index.tsx";
+import { CatalogItemPageRoute } from "./routes/item.tsx";
+import { EditPageRoute } from "./routes/edit.tsx";
 import { NotFoundRoute } from "./routes/not-found.tsx";
 
 function StaticRoute() {
@@ -18,6 +19,7 @@ export function App() {
   return (
     <Router>
       <IndexPageRoute />
+      <EditPageRoute />
       <CatalogItemPageRoute />
       <StaticRoute />
       <NotFoundRoute />

--- a/src/components/catalog.tsx
+++ b/src/components/catalog.tsx
@@ -60,78 +60,83 @@ export function Catalog(props: CatalogProps) {
             >
               {category}
             </A>
-          ))}
+          ))
+            .join(", ")}
         </DIV>
       </DIV>
 
       {props.items.length !== 0
         ? (
           <UL class="catalog-list">
-            {props.items.map((item) => (
-              <LI class="catalog-item">
-                <A
-                  href={`/${item.formId}`}
-                  class="item-content"
-                  style="text-decoration: none; color: inherit;"
-                >
-                  <DIV class="item-thumbnails">
-                    {(() => {
-                      const imagePreviews = item.previews.filter((preview) =>
-                        preview.src.match(/\.(jpg|jpeg)$/i)
-                      );
-                      if (imagePreviews.length > 0) {
-                        const preview = imagePreviews[0];
-                        return (
-                          <IMG
-                            src={getThumbnailPath(preview.src)}
-                            alt={preview.alt}
-                            class="item-thumbnail"
-                            loading="lazy"
-                            width="120"
-                            decoding="async"
-                            fetchpriority="low"
-                          />
-                        );
-                      } else {
-                        return (
-                          <DIV class="item-thumbnail placeholder">
-                            <DIV class="placeholder-content">
-                              <SPAN class="placeholder-text">No Preview</SPAN>
-                            </DIV>
-                          </DIV>
-                        );
-                      }
-                    })()}
-                  </DIV>
-                  <DIV class="item-info">
-                    <DIV class="item-title">
-                      {item.description}
-                    </DIV>
-                    <DIV class="item-details">
-                      <DIV class="item-specs">
-                        <SPAN class="spec-item">Category: {item.category}</SPAN>
-                        <SPAN class="spec-item">Size: {item.size}</SPAN>
-                        <SPAN class="spec-item">Paper: {item.paper}</SPAN>
-                        <SPAN class="spec-item">Color: {item.color}</SPAN>
-                        <SPAN class="spec-item">Sides: {item.sides}</SPAN>
-                        <SPAN class="spec-item">Unit: {item.unit}</SPAN>
-                        {item.previews.some((preview) => preview.pdf)
-                          ? (
-                            <SPAN
-                              class="spec-item"
-                              style="cursor: pointer;"
-                              onclick={`event.stopPropagation(); location.href = '/${item.formId}#previews'`}
-                            >
-                              PDF: Available
-                            </SPAN>
-                          )
-                          : ""}
+            {props.items
+              .map((item) => {
+                const imagePreviews = item.previews.filter((preview) =>
+                  preview.src.match(/\.(jpg|jpeg)$/i)
+                );
+
+                const thumbnailElement = imagePreviews.length > 0
+                  ? (
+                    <IMG
+                      src={getThumbnailPath(imagePreviews[0].src)}
+                      alt={imagePreviews[0].alt}
+                      class="item-thumbnail"
+                      loading="lazy"
+                      width="120"
+                      decoding="async"
+                      fetchpriority="low"
+                    />
+                  )
+                  : (
+                    <DIV class="item-thumbnail placeholder">
+                      <DIV class="placeholder-content">
+                        <SPAN class="placeholder-text">No Preview</SPAN>
                       </DIV>
                     </DIV>
-                  </DIV>
-                </A>
-              </LI>
-            ))}
+                  );
+
+                return (
+                  <LI class="catalog-item">
+                    <A
+                      href={`/${item.formId}`}
+                      class="item-content"
+                      style="text-decoration: none; color: inherit;"
+                    >
+                      <DIV class="item-thumbnails">
+                        {thumbnailElement}
+                      </DIV>
+                      <DIV class="item-info">
+                        <DIV class="item-title">
+                          {item.description}
+                        </DIV>
+                        <DIV class="item-details">
+                          <DIV class="item-specs">
+                            <SPAN class="spec-item">
+                              Category: {item.category}
+                            </SPAN>
+                            <SPAN class="spec-item">Size: {item.size}</SPAN>
+                            <SPAN class="spec-item">Paper: {item.paper}</SPAN>
+                            <SPAN class="spec-item">Color: {item.color}</SPAN>
+                            <SPAN class="spec-item">Sides: {item.sides}</SPAN>
+                            <SPAN class="spec-item">Unit: {item.unit}</SPAN>
+                            {item.previews.some((preview) => preview.pdf)
+                              ? (
+                                <SPAN
+                                  class="spec-item"
+                                  style="cursor: pointer;"
+                                  onclick={`event.stopPropagation(); location.href = '/${item.formId}#previews'`}
+                                >
+                                  PDF: Available
+                                </SPAN>
+                              )
+                              : ""}
+                          </DIV>
+                        </DIV>
+                      </DIV>
+                    </A>
+                  </LI>
+                );
+              })
+              .join("")}
           </UL>
         )
         : (

--- a/src/components/catalog.tsx
+++ b/src/components/catalog.tsx
@@ -55,7 +55,7 @@ export function Catalog(props: CatalogProps) {
         <DIV class="category-links">
           {categories.map((category) => (
             <A
-              href={`/?search=${category}`}
+              href={props.search === category ? "/" : `/?search=${category}`}
               class={props.search === category ? "active" : ""}
             >
               {category}
@@ -69,7 +69,11 @@ export function Catalog(props: CatalogProps) {
           <UL class="catalog-list">
             {props.items.map((item) => (
               <LI class="catalog-item">
-                <DIV class="item-content">
+                <A
+                  href={`/${item.formId}`}
+                  class="item-content"
+                  style="text-decoration: none; color: inherit;"
+                >
                   <DIV class="item-thumbnails">
                     {(() => {
                       const imagePreviews = item.previews.filter((preview) =>
@@ -78,35 +82,31 @@ export function Catalog(props: CatalogProps) {
                       if (imagePreviews.length > 0) {
                         const preview = imagePreviews[0];
                         return (
-                          <A href={`/${item.formId}`}>
-                            <IMG
-                              src={getThumbnailPath(preview.src)}
-                              alt={preview.alt}
-                              class="item-thumbnail"
-                              loading="lazy"
-                              width="120"
-                              decoding="async"
-                              fetchpriority="low"
-                            />
-                          </A>
+                          <IMG
+                            src={getThumbnailPath(preview.src)}
+                            alt={preview.alt}
+                            class="item-thumbnail"
+                            loading="lazy"
+                            width="120"
+                            decoding="async"
+                            fetchpriority="low"
+                          />
                         );
                       } else {
                         return (
-                          <A href={`/${item.formId}`}>
-                            <DIV class="item-thumbnail placeholder">
-                              <DIV class="placeholder-content">
-                                <SPAN class="placeholder-text">No Preview</SPAN>
-                              </DIV>
+                          <DIV class="item-thumbnail placeholder">
+                            <DIV class="placeholder-content">
+                              <SPAN class="placeholder-text">No Preview</SPAN>
                             </DIV>
-                          </A>
+                          </DIV>
                         );
                       }
                     })()}
                   </DIV>
                   <DIV class="item-info">
-                    <A href={`/${item.formId}`} class="item-title">
+                    <DIV class="item-title">
                       {item.description}
-                    </A>
+                    </DIV>
                     <DIV class="item-details">
                       <DIV class="item-specs">
                         <SPAN class="spec-item">Category: {item.category}</SPAN>
@@ -120,7 +120,7 @@ export function Catalog(props: CatalogProps) {
                             <SPAN
                               class="spec-item"
                               style="cursor: pointer;"
-                              onclick={`location.href = '/${item.formId}#previews'`}
+                              onclick={`event.stopPropagation(); location.href = '/${item.formId}#previews'`}
                             >
                               PDF: Available
                             </SPAN>
@@ -129,7 +129,7 @@ export function Catalog(props: CatalogProps) {
                       </DIV>
                     </DIV>
                   </DIV>
-                </DIV>
+                </A>
               </LI>
             ))}
           </UL>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -13,12 +13,14 @@ export function Navbar() {
           />
           <DIV class="brand-text">
             <DIV class="brand-primary">SNF</DIV>
-            <DIV class="brand-secondary">Printing</DIV>
+            <DIV class="brand-secondary">Forms</DIV>
           </DIV>
         </A>
-        <A href="tel:+17149016868" class="phone-link">
-          (714) 901-6868
-        </A>
+        <DIV style="display: flex; gap: 1rem; align-items: center;">
+          <A href="tel:+17149016868" class="phone-link">
+            (714) 901-6868
+          </A>
+        </DIV>
       </DIV>
     </NAV>
   );

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -1,11 +1,44 @@
 import type { CatalogItem } from "#/lib/snfforms.ts";
 
-const catalogItemsText = await Deno.readTextFile("./public/catalog.json");
-export const catalogItems = JSON.parse(catalogItemsText) as CatalogItem[];
+export enum CatalogFileType {
+  JPG = "jpg",
+  WEBP = "webp",
+  PDF = "pdf",
+}
 
-/**
- * findCatalogItem gets a catalog item by formId.
- */
-export function findCatalogItem(formId: string) {
-  return catalogItems.find((item) => item.formId === formId);
+export interface CatalogService {
+  /**
+   * getItems gets all catalog items.
+   */
+  getItems(): Promise<CatalogItem[] | undefined>;
+
+  /**
+   * setItems sets all catalog items.
+   */
+  setItems(items: CatalogItem[]): Promise<void>;
+
+  /**
+   * getFile gets a file by type and filename.
+   */
+  getFile(
+    type: CatalogFileType,
+    filename: string,
+  ): Promise<Uint8Array | undefined>;
+
+  /**
+   * setFile sets a file by type and filename.
+   */
+  setFile(
+    type: CatalogFileType,
+    filename: string,
+    data: Uint8Array,
+  ): Promise<void>;
+
+  /**
+   * removeFile removes a file by type and filename.
+   */
+  removeFile(
+    type: CatalogFileType,
+    filename: string,
+  ): Promise<void>;
 }

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -1,0 +1,62 @@
+import { get, remove, set } from "@kitsonk/kv-toolbox/blob";
+import type { CatalogItem } from "./snfforms.ts";
+import type { CatalogService } from "./catalog.ts";
+import { CatalogFileType } from "./catalog.ts";
+
+export const key = await Deno.openKv();
+
+export const CatalogKvKey = {
+  CATALOG_ITEMS: "catalog_items",
+  CATALOG_FILES_JPG: "catalog_files_jpg",
+  CATALOG_FILES_WEBP: "catalog_files_webp",
+  CATALOG_FILES_PDF: "catalog_files_pdf",
+};
+
+function fileKey(type: CatalogFileType, filename: string) {
+  return [
+    ({
+      [CatalogFileType.JPG]: CatalogKvKey.CATALOG_FILES_JPG,
+      [CatalogFileType.WEBP]: CatalogKvKey.CATALOG_FILES_WEBP,
+      [CatalogFileType.PDF]: CatalogKvKey.CATALOG_FILES_PDF,
+    })[type],
+    filename,
+  ];
+}
+
+export class KvCatalogService implements CatalogService {
+  public constructor(private readonly kv: Deno.Kv) {}
+
+  async getItems(): Promise<CatalogItem[] | undefined> {
+    const result = await this.kv.get<CatalogItem[]>([
+      CatalogKvKey.CATALOG_ITEMS,
+    ]);
+    return (result?.value ?? undefined);
+  }
+
+  async setItems(items: CatalogItem[]): Promise<void> {
+    await this.kv.set([CatalogKvKey.CATALOG_ITEMS], items);
+  }
+
+  async getFile(
+    type: CatalogFileType,
+    filename: string,
+  ): Promise<Uint8Array | undefined> {
+    const result = await get(key, fileKey(type, filename));
+    return result?.value ?? undefined;
+  }
+
+  async setFile(
+    type: CatalogFileType,
+    filename: string,
+    data: Uint8Array,
+  ): Promise<void> {
+    await set(key, fileKey(type, filename), data);
+  }
+
+  async removeFile(
+    type: CatalogFileType,
+    filename: string,
+  ): Promise<void> {
+    await remove(key, fileKey(type, filename));
+  }
+}

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -3,7 +3,7 @@ import type { CatalogItem } from "./snfforms.ts";
 import type { CatalogService } from "./catalog.ts";
 import { CatalogFileType } from "./catalog.ts";
 
-export const key = await Deno.openKv();
+export const kv = await Deno.openKv();
 
 export const CatalogKvKey = {
   CATALOG_ITEMS: "catalog_items",
@@ -26,6 +26,12 @@ function fileKey(type: CatalogFileType, filename: string) {
 export class KvCatalogService implements CatalogService {
   public constructor(private readonly kv: Deno.Kv) {}
 
+  async seed() {
+    const itemsText = await Deno.readTextFile("./public/catalog.json");
+    const items = JSON.parse(itemsText) as CatalogItem[];
+    await this.setItems(items);
+  }
+
   async getItems(): Promise<CatalogItem[] | undefined> {
     const result = await this.kv.get<CatalogItem[]>([
       CatalogKvKey.CATALOG_ITEMS,
@@ -37,11 +43,62 @@ export class KvCatalogService implements CatalogService {
     await this.kv.set([CatalogKvKey.CATALOG_ITEMS], items);
   }
 
+  async addItem(item: CatalogItem): Promise<boolean> {
+    const catalogItems = await this.getItems();
+    if (!catalogItems) {
+      return false;
+    }
+
+    // Check if item already exists
+    const existingIndex = catalogItems.findIndex((existingItem) =>
+      existingItem.formId === item.formId
+    );
+    if (existingIndex !== -1) {
+      return false; // Item already exists
+    }
+
+    catalogItems.push(item);
+    await this.setItems(catalogItems);
+    return true;
+  }
+
+  async updateItem(formId: string, updatedItem: CatalogItem): Promise<boolean> {
+    const catalogItems = await this.getItems();
+    if (!catalogItems) {
+      return false;
+    }
+
+    const itemIndex = catalogItems.findIndex((item) => item.formId === formId);
+    if (itemIndex === -1) {
+      return false; // Item not found
+    }
+
+    catalogItems[itemIndex] = updatedItem;
+    await this.setItems(catalogItems);
+    return true;
+  }
+
+  async deleteItem(formId: string): Promise<boolean> {
+    const catalogItems = await this.getItems();
+    if (!catalogItems) {
+      return false;
+    }
+
+    const itemIndex = catalogItems.findIndex((item) => item.formId === formId);
+    if (itemIndex === -1) {
+      return false;
+    }
+
+    catalogItems.splice(itemIndex, 1);
+    await this.setItems(catalogItems);
+    return true;
+  }
+
   async getFile(
     type: CatalogFileType,
     filename: string,
   ): Promise<Uint8Array | undefined> {
-    const result = await get(key, fileKey(type, filename));
+    const result = await get(this.kv, fileKey(type, filename));
     return result?.value ?? undefined;
   }
 
@@ -50,13 +107,13 @@ export class KvCatalogService implements CatalogService {
     filename: string,
     data: Uint8Array,
   ): Promise<void> {
-    await set(key, fileKey(type, filename), data);
+    await set(this.kv, fileKey(type, filename), data);
   }
 
   async removeFile(
     type: CatalogFileType,
     filename: string,
   ): Promise<void> {
-    await remove(key, fileKey(type, filename));
+    await remove(this.kv, fileKey(type, filename));
   }
 }

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -131,9 +131,19 @@ export class KvCatalogService implements CatalogService {
       return null;
     }
 
-    // Create a simple hash of the items to detect changes.
+    // Create a comprehensive hash of the items to detect changes.
     const itemsHash = JSON.stringify(
-      items.map((item) => item.formId).toSorted(),
+      items.map((item) => ({
+        formId: item.formId,
+        category: item.category,
+        description: item.description,
+        size: item.size,
+        paper: item.paper,
+        color: item.color,
+        sides: item.sides,
+        unit: item.unit,
+        previews: item.previews,
+      })).toSorted((a, b) => a.formId.localeCompare(b.formId)),
     );
 
     // If we have a cached index and the items haven't changed, return it.

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -2,6 +2,7 @@ import { get, remove, set } from "@kitsonk/kv-toolbox/blob";
 import type { CatalogItem } from "./snfforms.ts";
 import type { CatalogService } from "./catalog.ts";
 import { CatalogFileType } from "./catalog.ts";
+import { createOrama, type Orama } from "./orama.ts";
 
 export const kv = await Deno.openKv();
 
@@ -24,6 +25,9 @@ function fileKey(type: CatalogFileType, filename: string) {
 }
 
 export class KvCatalogService implements CatalogService {
+  private oramaIndex: Orama | null = null;
+  private lastItemsHash: string | null = null;
+
   public constructor(private readonly kv: Deno.Kv) {}
 
   async seed() {
@@ -41,6 +45,7 @@ export class KvCatalogService implements CatalogService {
 
   async setItems(items: CatalogItem[]): Promise<void> {
     await this.kv.set([CatalogKvKey.CATALOG_ITEMS], items);
+    this.invalidateOramaIndex();
   }
 
   async addItem(item: CatalogItem): Promise<boolean> {
@@ -115,5 +120,38 @@ export class KvCatalogService implements CatalogService {
     filename: string,
   ): Promise<void> {
     await remove(this.kv, fileKey(type, filename));
+  }
+
+  /**
+   * getOramaIndex gets the Orama search index, creating it if necessary.
+   */
+  async getOramaIndex(): Promise<Orama | null> {
+    const items = await this.getItems();
+    if (!items) {
+      return null;
+    }
+
+    // Create a simple hash of the items to detect changes.
+    const itemsHash = JSON.stringify(
+      items.map((item) => item.formId).toSorted(),
+    );
+
+    // If we have a cached index and the items haven't changed, return it.
+    if (this.oramaIndex && this.lastItemsHash === itemsHash) {
+      return this.oramaIndex;
+    }
+
+    // Create a new index.
+    this.oramaIndex = await createOrama(items);
+    this.lastItemsHash = itemsHash;
+    return this.oramaIndex;
+  }
+
+  /**
+   * invalidateOramaIndex clears the cached Orama index.
+   */
+  private invalidateOramaIndex(): void {
+    this.oramaIndex = null;
+    this.lastItemsHash = null;
   }
 }

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -54,7 +54,7 @@ export class KvCatalogService implements CatalogService {
       return false;
     }
 
-    // Check if item already exists
+    // Check if the item already exists.
     const existingIndex = catalogItems.findIndex((existingItem) =>
       existingItem.formId === item.formId
     );

--- a/src/lib/orama.ts
+++ b/src/lib/orama.ts
@@ -1,33 +1,39 @@
 import { create, insert, search } from "@orama/orama";
-import { catalogItems } from "./catalog.ts";
+import type { CatalogItem } from "#/lib/snfforms.ts";
+
+export type Orama = Awaited<ReturnType<typeof createOrama>>;
+
+export async function createOrama(catalogItems: CatalogItem[]) {
+  const db = await create({
+    schema: {
+      formId: "string",
+      category: "string",
+      description: "string",
+      size: "string",
+      paper: "string",
+      color: "string",
+      sides: "string",
+      unit: "string",
+    },
+  });
+
+  for (const catalogItem of catalogItems) {
+    await insert(db, catalogItem);
+  }
+
+  return db;
+}
 
 /**
  * searchCatalog searches the catalog for a term.
  *
  * @see https://docs.orama.com/docs/orama-js/search
  */
-export function searchCatalog(term: string) {
+export function searchCatalog(db: Orama, term: string) {
   return search(db, {
     term,
     threshold: 1,
     tolerance: 0.95,
     limit: 500, // Dataset is small, pagination is negligible.
   });
-}
-
-const db = await create({
-  schema: {
-    formId: "string",
-    category: "string",
-    description: "string",
-    size: "string",
-    paper: "string",
-    color: "string",
-    sides: "string",
-    unit: "string",
-  },
-});
-
-for (const catalogItem of catalogItems) {
-  await insert(db, catalogItem);
 }

--- a/src/lib/snfforms.ts
+++ b/src/lib/snfforms.ts
@@ -15,3 +15,10 @@ export interface CatalogItemPreview {
   alt: string;
   pdf?: string;
 }
+
+export function findCatalogItem(
+  catalogItems: CatalogItem[],
+  formId: string,
+): CatalogItem | undefined {
+  return catalogItems.find((item) => item.formId === formId);
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -4,106 +4,57 @@ import { z } from "zod";
  * Validation schemas for catalog items and form data.
  */
 
-// Form ID validation: 3-10 characters, alphanumeric and hyphens only
-const formIdSchema = z
-  .string()
-  .min(3, "Form ID must be at least 3 characters")
-  .max(10, "Form ID must be no more than 10 characters")
-  .regex(
-    /^[a-zA-Z0-9-]+$/,
-    "Form ID must contain only letters, numbers, and hyphens",
-  );
+// Form ID validation requires a non-empty string.
+const formIdSchema = z.string().min(1, "Form ID is required").trim();
 
-// Common field validation: trimmed string with length limits
-const createFieldSchema = (maxLength: number = 100) =>
-  z
-    .string()
-    .min(1, "This field is required")
-    .max(maxLength, `This field must be ${maxLength} characters or less`)
-    .trim();
+// Common field validation requires a non-empty string.
+const createFieldSchema = () =>
+  z.string().min(1, "This field is required").trim();
 
-// Catalog item preview validation
+// Catalog item preview validation schema.
 const catalogItemPreviewSchema = z.object({
   src: z.string().min(1, "Preview source is required"),
   alt: z.string().min(1, "Preview alt text is required"),
   pdf: z.string().optional(),
 });
 
-// Complete catalog item validation schema
+// Complete catalog item validation schema.
 export const catalogItemSchema = z.object({
   formId: formIdSchema,
-  category: createFieldSchema(50),
-  description: createFieldSchema(200),
-  size: createFieldSchema(50),
-  paper: createFieldSchema(50),
-  color: createFieldSchema(50),
-  sides: createFieldSchema(50),
-  unit: createFieldSchema(50),
+  category: createFieldSchema(),
+  description: createFieldSchema(),
+  size: createFieldSchema(),
+  paper: createFieldSchema(),
+  color: createFieldSchema(),
+  sides: createFieldSchema(),
+  unit: createFieldSchema(),
   previews: z.array(catalogItemPreviewSchema).default([]),
 });
 
-// Form data validation schema for POST requests
+// Form data validation schema for POST requests.
 export const catalogItemFormSchema = z.object({
   formId: formIdSchema,
-  category: createFieldSchema(50),
-  description: createFieldSchema(200),
-  size: createFieldSchema(50),
-  paper: createFieldSchema(50),
-  color: createFieldSchema(50),
-  sides: createFieldSchema(50),
-  unit: createFieldSchema(50),
+  category: createFieldSchema(),
+  description: createFieldSchema(),
+  size: createFieldSchema(),
+  paper: createFieldSchema(),
+  color: createFieldSchema(),
+  sides: createFieldSchema(),
+  unit: createFieldSchema(),
 });
 
-// Search query validation
-export const searchQuerySchema = z
-  .string()
-  .min(1, "Search query cannot be empty")
-  .max(100, "Search query must be 100 characters or less")
-  .trim()
-  .optional();
+// Search query validation schema.
+export const searchQuerySchema = z.string().trim().optional();
 
-// URL parameter validation
+// URL parameter validation schema.
 export const formIdParamSchema = z.object({
   formId: formIdSchema,
 });
 
-// Type exports for TypeScript
+// Type exports for TypeScript.
 export type CatalogItemFormData = z.infer<typeof catalogItemFormSchema>;
 export type SearchQuery = z.infer<typeof searchQuerySchema>;
 export type FormIdParam = z.infer<typeof formIdParamSchema>;
-
-/**
- * Validates form data and returns a standardized error response if validation fails.
- */
-export function validateFormData<T>(
-  schema: z.ZodSchema<T>,
-  data: unknown,
-): { success: true; data: T } | {
-  success: false;
-  error: string;
-  status: number;
-} {
-  try {
-    const validatedData = schema.parse(data);
-    return { success: true, data: validatedData };
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      const errorMessage = error.issues
-        .map((err: z.ZodIssue) => `${err.path.join(".")}: ${err.message}`)
-        .join(", ");
-      return {
-        success: false,
-        error: `Validation failed: ${errorMessage}`,
-        status: 400,
-      };
-    }
-    return {
-      success: false,
-      error: "Invalid data format",
-      status: 400,
-    };
-  }
-}
 
 /**
  * Safely parses form data from FormData object.
@@ -113,5 +64,6 @@ export function parseFormData(formData: FormData): Record<string, string> {
   for (const [key, value] of formData.entries()) {
     data[key] = value.toString().trim();
   }
+
   return data;
 }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,117 @@
+import { z } from "zod";
+
+/**
+ * Validation schemas for catalog items and form data.
+ */
+
+// Form ID validation: 3-10 characters, alphanumeric and hyphens only
+const formIdSchema = z
+  .string()
+  .min(3, "Form ID must be at least 3 characters")
+  .max(10, "Form ID must be no more than 10 characters")
+  .regex(
+    /^[a-zA-Z0-9-]+$/,
+    "Form ID must contain only letters, numbers, and hyphens",
+  );
+
+// Common field validation: trimmed string with length limits
+const createFieldSchema = (maxLength: number = 100) =>
+  z
+    .string()
+    .min(1, "This field is required")
+    .max(maxLength, `This field must be ${maxLength} characters or less`)
+    .trim();
+
+// Catalog item preview validation
+const catalogItemPreviewSchema = z.object({
+  src: z.string().min(1, "Preview source is required"),
+  alt: z.string().min(1, "Preview alt text is required"),
+  pdf: z.string().optional(),
+});
+
+// Complete catalog item validation schema
+export const catalogItemSchema = z.object({
+  formId: formIdSchema,
+  category: createFieldSchema(50),
+  description: createFieldSchema(200),
+  size: createFieldSchema(50),
+  paper: createFieldSchema(50),
+  color: createFieldSchema(50),
+  sides: createFieldSchema(50),
+  unit: createFieldSchema(50),
+  previews: z.array(catalogItemPreviewSchema).default([]),
+});
+
+// Form data validation schema for POST requests
+export const catalogItemFormSchema = z.object({
+  formId: formIdSchema,
+  category: createFieldSchema(50),
+  description: createFieldSchema(200),
+  size: createFieldSchema(50),
+  paper: createFieldSchema(50),
+  color: createFieldSchema(50),
+  sides: createFieldSchema(50),
+  unit: createFieldSchema(50),
+});
+
+// Search query validation
+export const searchQuerySchema = z
+  .string()
+  .min(1, "Search query cannot be empty")
+  .max(100, "Search query must be 100 characters or less")
+  .trim()
+  .optional();
+
+// URL parameter validation
+export const formIdParamSchema = z.object({
+  formId: formIdSchema,
+});
+
+// Type exports for TypeScript
+export type CatalogItemFormData = z.infer<typeof catalogItemFormSchema>;
+export type SearchQuery = z.infer<typeof searchQuerySchema>;
+export type FormIdParam = z.infer<typeof formIdParamSchema>;
+
+/**
+ * Validates form data and returns a standardized error response if validation fails.
+ */
+export function validateFormData<T>(
+  schema: z.ZodSchema<T>,
+  data: unknown,
+): { success: true; data: T } | {
+  success: false;
+  error: string;
+  status: number;
+} {
+  try {
+    const validatedData = schema.parse(data);
+    return { success: true, data: validatedData };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const errorMessage = error.issues
+        .map((err: z.ZodIssue) => `${err.path.join(".")}: ${err.message}`)
+        .join(", ");
+      return {
+        success: false,
+        error: `Validation failed: ${errorMessage}`,
+        status: 400,
+      };
+    }
+    return {
+      success: false,
+      error: "Invalid data format",
+      status: 400,
+    };
+  }
+}
+
+/**
+ * Safely parses form data from FormData object.
+ */
+export function parseFormData(formData: FormData): Record<string, string> {
+  const data: Record<string, string> = {};
+  for (const [key, value] of formData.entries()) {
+    data[key] = value.toString().trim();
+  }
+  return data;
+}

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -1,0 +1,55 @@
+import { Get, Router } from "@fartlabs/rtx";
+import { kv, KvCatalogService } from "#/lib/kv.ts";
+
+const catalogService = new KvCatalogService(kv);
+
+export function ApiRoute() {
+  return (
+    <Router>
+      <Get
+        pattern="/api/catalog"
+        handler={async (ctx: { request: Request }) => {
+          try {
+            const catalogItems = await catalogService.getItems();
+
+            return new Response(
+              JSON.stringify({
+                success: true,
+                data: catalogItems || [],
+                count: catalogItems?.length || 0,
+              }),
+              {
+                headers: {
+                  "Content-Type": "application/json",
+                  "Access-Control-Allow-Origin": "*",
+                  "Access-Control-Allow-Methods": "GET",
+                  "Access-Control-Allow-Headers": "Content-Type",
+                },
+              },
+            );
+          } catch (error) {
+            console.error("Failed to fetch catalog:", error);
+
+            return new Response(
+              JSON.stringify({
+                success: false,
+                error: "Failed to fetch catalog",
+                data: [],
+                count: 0,
+              }),
+              {
+                headers: {
+                  "Content-Type": "application/json",
+                  "Access-Control-Allow-Origin": "*",
+                  "Access-Control-Allow-Methods": "GET",
+                  "Access-Control-Allow-Headers": "Content-Type",
+                },
+                status: 500,
+              },
+            );
+          }
+        }}
+      />
+    </Router>
+  );
+}

--- a/src/routes/edit.tsx
+++ b/src/routes/edit.tsx
@@ -234,7 +234,9 @@ export function EditPage(props: EditPageProps) {
             {props.items
               .map((item) => (
                 <TR>
-                  <TD>{item.formId}</TD>
+                  <TD>
+                    <A href={`/${item.formId}`}>{item.formId}</A>
+                  </TD>
                   <TD>{item.description}</TD>
                   <TD>{item.category}</TD>
                   <TD>

--- a/src/routes/edit.tsx
+++ b/src/routes/edit.tsx
@@ -43,7 +43,7 @@ export function EditPageRoute() {
           const formData = await ctx.request.formData();
           const catalogService = new KvCatalogService(kv);
 
-          // Check admin password from Authorization header.
+          // Check the admin password from the Authorization header.
           const authHeader = ctx.request.headers.get("Authorization");
           const adminPassword = authHeader?.replace("Bearer ", "");
           const expectedPassword = Deno.env.get("SECRET_PASSWORD");
@@ -59,10 +59,14 @@ export function EditPageRoute() {
           }
 
           const formId = formData.get("formId") as string;
+          const url = new URL(ctx.request.url);
+          const originalFormId = url.searchParams.get("formId");
           const catalogItems = (await catalogService.getItems()) ?? [];
-          const existingItem = catalogItems.find((item) =>
-            item.formId === formId
-          );
+
+          // Use the original formId from the URL to find the existing item, not the potentially changed formId from the form.
+          const existingItem = originalFormId
+            ? catalogItems.find((item) => item.formId === originalFormId)
+            : catalogItems.find((item) => item.formId === formId);
 
           // Create the item data.
           const itemData: CatalogItem = {
@@ -79,10 +83,22 @@ export function EditPageRoute() {
 
           let success: boolean;
           if (existingItem) {
-            // Update existing item.
-            success = await catalogService.updateItem(formId, itemData);
+            if (originalFormId && originalFormId !== formId) {
+              // The formId has changed, so delete the old item and create a new one.
+              const deleteSuccess = await catalogService.deleteItem(
+                originalFormId,
+              );
+              if (deleteSuccess) {
+                success = await catalogService.addItem(itemData);
+              } else {
+                success = false;
+              }
+            } else {
+              // Update the existing item with the same formId.
+              success = await catalogService.updateItem(formId, itemData);
+            }
           } else {
-            // Add new item.
+            // Add a new item.
             success = await catalogService.addItem(itemData);
           }
 
@@ -159,7 +175,7 @@ export function EditPageRoute() {
             );
           }
 
-          // Check admin password from Authorization header.
+          // Check the admin password from the Authorization header.
           const authHeader = ctx.request.headers.get("Authorization");
           const adminPassword = authHeader?.replace("Bearer ", "");
           const expectedPassword = Deno.env.get("SECRET_PASSWORD");
@@ -270,13 +286,13 @@ async function handleEditFormSubmit(event) {
     return false;
   }
   
-  // Get admin password.
+  // Get the admin password.
   const password = prompt('Enter admin password to update this form:');
   if (!password) {
     return false;
   }
   
-  // Submit the form with password in Authorization header.
+  // Submit the form with the password in the Authorization header.
   try {
     const response = await fetch('/edit', {
       method: 'POST',
@@ -299,7 +315,7 @@ async function handleEditFormSubmit(event) {
   return true;
 }
 
-// Add event listener when page loads.
+// Add an event listener when the page loads.
 document.addEventListener('DOMContentLoaded', function() {
   const form = document.getElementById('edit-form');
   if (form) {
@@ -456,7 +472,7 @@ async function deleteItem(formId) {
     const result = await response.json();
     
     if (result.success) {
-      // Redirect to edit page after successful deletion.
+      // Redirect to the edit page after successful deletion.
       window.location.href = '/edit';
     } else {
       alert('Failed to delete item: ' + (result.error || 'Unknown error'));
@@ -490,13 +506,13 @@ async function handleFormSubmit(event) {
     return false;
   }
   
-  // Get admin password.
+  // Get the admin password.
   const password = prompt('Enter admin password to submit this form:');
   if (!password) {
     return false;
   }
   
-  // Check if form ID already exists.
+  // Check if the form ID already exists.
   const exists = await checkFormIdExists(formId);
   
   if (exists) {
@@ -511,12 +527,12 @@ async function handleFormSubmit(event) {
     }
   }
   
-  // Submit the form with password in Authorization header.
+  // Submit the form with the password in the Authorization header.
   const submitForm = document.createElement('form');
   submitForm.method = 'POST';
   submitForm.action = '/edit';
   
-  // Add all form fields.
+  // Add all the form fields.
   for (const [key, value] of formData.entries()) {
     const input = document.createElement('input');
     input.type = 'hidden';
@@ -551,7 +567,7 @@ async function handleFormSubmit(event) {
   return true;
 }
 
-// Add event listener when page loads.
+// Add an event listener when the page loads.
 document.addEventListener('DOMContentLoaded', function() {
   const form = document.getElementById('create-form');
   if (form) {

--- a/src/routes/edit.tsx
+++ b/src/routes/edit.tsx
@@ -116,47 +116,110 @@ export function EditPageRoute() {
             previews: existingItem ? existingItem.previews : [], // Keep existing previews or empty for new items.
           };
 
-          let success: boolean;
+          // Handle different scenarios with specific error messages.
           if (existingItem) {
             if (originalFormId && originalFormId !== formId) {
-              // The formId has changed, so we need to handle this carefully to avoid data loss.
-              // First, check if the new formId already exists.
+              // The formId has changed, check if the new formId already exists.
               const newItemExists = catalogItems.find((item) =>
                 item.formId === formId
               );
               if (newItemExists) {
-                success = false; // Cannot change to an existing formId
-              } else {
-                // Safe to proceed: delete old item and create new one.
-                const deleteSuccess = await catalogService.deleteItem(
-                  originalFormId,
+                return new Response(
+                  JSON.stringify({
+                    success: false,
+                    error:
+                      `Form ID "${formId}" already exists. Please choose a different Form ID.`,
+                  }),
+                  {
+                    headers: { "Content-Type": "application/json" },
+                    status: 400,
+                  },
                 );
-                if (deleteSuccess) {
-                  success = await catalogService.addItem(itemData);
-                } else {
-                  success = false;
-                }
+              }
+
+              // Safe to proceed: delete old item and create new one.
+              const deleteSuccess = await catalogService.deleteItem(
+                originalFormId,
+              );
+              if (!deleteSuccess) {
+                return new Response(
+                  JSON.stringify({
+                    success: false,
+                    error:
+                      "Failed to delete the original item. Please try again.",
+                  }),
+                  {
+                    headers: { "Content-Type": "application/json" },
+                    status: 500,
+                  },
+                );
+              }
+
+              const addSuccess = await catalogService.addItem(itemData);
+              if (!addSuccess) {
+                return new Response(
+                  JSON.stringify({
+                    success: false,
+                    error:
+                      "Failed to create the updated item. Please try again.",
+                  }),
+                  {
+                    headers: { "Content-Type": "application/json" },
+                    status: 500,
+                  },
+                );
               }
             } else {
               // Update the existing item with the same formId.
-              success = await catalogService.updateItem(formId, itemData);
+              const updateSuccess = await catalogService.updateItem(
+                formId,
+                itemData,
+              );
+              if (!updateSuccess) {
+                return new Response(
+                  JSON.stringify({
+                    success: false,
+                    error: "Failed to update the item. Please try again.",
+                  }),
+                  {
+                    headers: { "Content-Type": "application/json" },
+                    status: 500,
+                  },
+                );
+              }
             }
           } else {
-            // Add a new item.
-            success = await catalogService.addItem(itemData);
-          }
-
-          if (!success) {
-            return new Response(
-              JSON.stringify({
-                success: false,
-                error: "Failed to save item. Please try again.",
-              }),
-              {
-                headers: { "Content-Type": "application/json" },
-                status: 500,
-              },
+            // Add a new item and check if formId already exists.
+            const itemExists = catalogItems.find((item) =>
+              item.formId === formId
             );
+            if (itemExists) {
+              return new Response(
+                JSON.stringify({
+                  success: false,
+                  error:
+                    `Form ID "${formId}" already exists. Please choose a different Form ID.`,
+                }),
+                {
+                  headers: { "Content-Type": "application/json" },
+                  status: 400,
+                },
+              );
+            }
+
+            const addSuccess = await catalogService.addItem(itemData);
+            if (!addSuccess) {
+              return new Response(
+                JSON.stringify({
+                  success: false,
+                  error: "Failed to create the new item. Please try again.",
+                }),
+                {
+                  headers: { "Content-Type": "application/json" },
+                  status: 500,
+                },
+              );
+            }
           }
 
           return new Response(

--- a/src/routes/edit.tsx
+++ b/src/routes/edit.tsx
@@ -20,11 +20,7 @@ import { RedirectPage } from "#/components/redirect.tsx";
 import { NotFoundPage } from "#/components/not-found.tsx";
 import type { CatalogItem } from "#/lib/snfforms.ts";
 import { kv, KvCatalogService } from "#/lib/kv.ts";
-import {
-  catalogItemFormSchema,
-  parseFormData,
-  validateFormData,
-} from "#/lib/validation.ts";
+import { catalogItemFormSchema, parseFormData } from "#/lib/validation.ts";
 
 const catalogService = new KvCatalogService(kv);
 
@@ -48,12 +44,11 @@ export function EditPageRoute() {
         handler={async (ctx) => {
           const formData = await ctx.request.formData();
 
-          // Check the admin password from the Authorization header.
-          const authHeader = ctx.request.headers.get("Authorization");
-          const adminPassword = authHeader?.replace("Bearer ", "");
+          // Check the admin password from the form data.
+          const secretPassword = formData.get("password") as string;
           const expectedPassword = Deno.env.get("SECRET_PASSWORD");
 
-          if (!expectedPassword || adminPassword !== expectedPassword) {
+          if (!expectedPassword || secretPassword !== expectedPassword) {
             return new Response(
               <PasswordErrorPage />,
               {
@@ -63,22 +58,26 @@ export function EditPageRoute() {
             );
           }
 
-          // Parse and validate form data using Zod
+          // Parse and validate form data using Zod.
           const rawFormData = parseFormData(formData);
-          const validation = validateFormData(
-            catalogItemFormSchema,
-            rawFormData,
-          );
+
+          // Remove password from form data before validation since it's not part of the catalog item schema.
+          const { password: _, ...catalogData } = rawFormData;
+
+          const validation = catalogItemFormSchema.safeParse(catalogData);
 
           if (!validation.success) {
+            const errorMessage = validation.error.issues
+              .map((err) => `${err.path.join(".")}: ${err.message}`)
+              .join(", ");
             return new Response(
               JSON.stringify({
                 success: false,
-                error: validation.error,
+                error: `Validation failed: ${errorMessage}`,
               }),
               {
                 headers: { "Content-Type": "application/json" },
-                status: validation.status,
+                status: 400,
               },
             );
           }
@@ -161,7 +160,7 @@ export function EditPageRoute() {
           }
 
           return new Response(
-            <RedirectPage redirectUrl="/edit" />,
+            <RedirectPage redirectUrl={`/${formId}`} />,
             { headers: { "Content-Type": "text/html" } },
           );
         }}
@@ -222,11 +221,10 @@ export function EditPageRoute() {
             );
           }
 
-          // Check the admin password from the Authorization header.
-          const authHeader = ctx.request.headers.get("Authorization");
-          const adminPassword = authHeader?.replace("Bearer ", "");
+          // Check the admin password from the form data.
+          const formData = await ctx.request.formData();
+          const adminPassword = formData.get("password") as string;
           const expectedPassword = Deno.env.get("SECRET_PASSWORD");
-
           if (!expectedPassword || adminPassword !== expectedPassword) {
             return new Response(
               JSON.stringify({
@@ -293,20 +291,22 @@ export function EditPage(props: EditPageProps) {
               <TH>Category</TH>
               <TH>Actions</TH>
             </TR>
-            {props.items.map((item) => (
-              <TR>
-                <TD>
-                  <A href={`/${item.formId}`}>{item.formId}</A>
-                </TD>
-                <TD>{item.description}</TD>
-                <TD>{item.category}</TD>
-                <TD>
-                  <A href={`/edit/${item.formId}`} class="btn">
-                    Edit
-                  </A>
-                </TD>
-              </TR>
-            ))}
+            {props.items
+              .map((item) => (
+                <TR>
+                  <TD>
+                    <A href={`/${item.formId}`}>{item.formId}</A>
+                  </TD>
+                  <TD>{item.description}</TD>
+                  <TD>{item.category}</TD>
+                  <TD>
+                    <A href={`/edit/${item.formId}`} class="btn">
+                      Edit
+                    </A>
+                  </TD>
+                </TR>
+              ))
+              .join("")}
           </TBODY>
         </TABLE>
       </DIV>
@@ -330,24 +330,22 @@ async function handleEditFormSubmit(event) {
     return false;
   }
   
-  // Get the admin password.
-  const password = prompt('Enter admin password to update this form:');
+  // Get the admin password from the form.
+  const password = formData.get('password');
   if (!password) {
+    alert('Admin password is required');
     return false;
   }
   
-  // Submit the form with the password in the Authorization header.
+  // Submit the form data directly.
   try {
     const response = await fetch('/edit', {
       method: 'POST',
-      headers: {
-        'Authorization': \`Bearer \${password}\`,
-      },
       body: formData,
     });
     
     if (response.ok) {
-      window.location.href = '/edit';
+      window.location.href = \`/\${formId}\`;
     } else {
       alert('Failed to update form. Please check your password and try again.');
     }
@@ -474,6 +472,17 @@ export function EditItemPage(props: EditItemPageProps) {
             />
           </DIV>
 
+          <DIV class="form-group">
+            <LABEL for="password">Admin Password</LABEL>
+            <INPUT
+              type="password"
+              id="password"
+              name="password"
+              required="required"
+              placeholder="Enter admin password"
+            />
+          </DIV>
+
           <DIV class="form-actions">
             <DIV class="btn-group">
               <BUTTON type="submit" class="btn btn-primary">
@@ -505,12 +514,12 @@ async function deleteItem(formId) {
   }
 
   try {
+    const formData = new FormData();
+    formData.append('password', password);
+    
     const response = await fetch(\`/edit/\${formId}\`, {
       method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': \`Bearer \${password}\`,
-      },
+      body: formData,
     });
     
     const result = await response.json();
@@ -550,9 +559,10 @@ async function handleFormSubmit(event) {
     return false;
   }
   
-  // Get the admin password.
-  const password = prompt('Enter admin password to submit this form:');
+  // Get the admin password from the form.
+  const password = formData.get('password');
   if (!password) {
+    alert('Admin password is required');
     return false;
   }
   
@@ -571,18 +581,15 @@ async function handleFormSubmit(event) {
     }
   }
   
-  // Submit with custom headers using fetch.
+  // Submit the form data directly.
   try {
     const response = await fetch('/edit', {
       method: 'POST',
-      headers: {
-        'Authorization': \`Bearer \${password}\`,
-      },
       body: formData,
     });
     
     if (response.ok) {
-      window.location.href = '/edit';
+      window.location.href = \`/\${formId}\`;
     } else {
       alert('Failed to submit form. Please check your password and try again.');
     }
@@ -702,6 +709,17 @@ export function CreateItemPage() {
               name="unit"
               required="required"
               placeholder="Enter unit (e.g., Each, Pack, Box)"
+            />
+          </DIV>
+
+          <DIV class="form-group">
+            <LABEL for="password">Admin Password</LABEL>
+            <INPUT
+              type="password"
+              id="password"
+              name="password"
+              required="required"
+              placeholder="Enter admin password"
             />
           </DIV>
 

--- a/src/routes/edit.tsx
+++ b/src/routes/edit.tsx
@@ -495,7 +495,8 @@ export function EditItemPage(props: EditItemPageProps) {
             <BUTTON
               type="button"
               class="btn btn-danger"
-              onclick={`if (confirm('Are you sure you want to delete ${props.item.formId}? This action cannot be undone.')) { deleteItem('${props.item.formId}'); }`}
+              data-form-id={props.item.formId}
+              onclick="handleDeleteClick(this)"
             >
               Delete Item
             </BUTTON>
@@ -533,6 +534,13 @@ async function deleteItem(formId) {
   } catch (error) {
     console.error('Error deleting item:', error);
     alert('An error occurred while deleting the item');
+  }
+}
+
+function handleDeleteClick(button) {
+  const formId = button.getAttribute('data-form-id');
+  if (confirm('Are you sure you want to delete ' + formId + '? This action cannot be undone.')) {
+    deleteItem(formId);
   }
 }
 `;

--- a/src/routes/edit.tsx
+++ b/src/routes/edit.tsx
@@ -20,6 +20,13 @@ import { RedirectPage } from "#/components/redirect.tsx";
 import { NotFoundPage } from "#/components/not-found.tsx";
 import type { CatalogItem } from "#/lib/snfforms.ts";
 import { kv, KvCatalogService } from "#/lib/kv.ts";
+import {
+  catalogItemFormSchema,
+  parseFormData,
+  validateFormData,
+} from "#/lib/validation.ts";
+
+const catalogService = new KvCatalogService(kv);
 
 export function EditPageRoute() {
   return (
@@ -27,7 +34,6 @@ export function EditPageRoute() {
       <Get
         pattern="/edit"
         handler={async (_ctx) => {
-          const catalogService = new KvCatalogService(kv);
           const catalogItems = (await catalogService.getItems()) ?? [];
 
           return new Response(
@@ -41,7 +47,6 @@ export function EditPageRoute() {
         pattern="/edit"
         handler={async (ctx) => {
           const formData = await ctx.request.formData();
-          const catalogService = new KvCatalogService(kv);
 
           // Check the admin password from the Authorization header.
           const authHeader = ctx.request.headers.get("Authorization");
@@ -58,40 +63,80 @@ export function EditPageRoute() {
             );
           }
 
-          const formId = formData.get("formId") as string;
+          // Parse and validate form data using Zod
+          const rawFormData = parseFormData(formData);
+          const validation = validateFormData(
+            catalogItemFormSchema,
+            rawFormData,
+          );
+
+          if (!validation.success) {
+            return new Response(
+              JSON.stringify({
+                success: false,
+                error: validation.error,
+              }),
+              {
+                headers: { "Content-Type": "application/json" },
+                status: validation.status,
+              },
+            );
+          }
+
+          const {
+            formId,
+            category,
+            description,
+            size,
+            paper,
+            color,
+            sides,
+            unit,
+          } = validation.data;
+
           const url = new URL(ctx.request.url);
           const originalFormId = url.searchParams.get("formId");
           const catalogItems = (await catalogService.getItems()) ?? [];
 
           // Use the original formId from the URL to find the existing item, not the potentially changed formId from the form.
+          // If no originalFormId is provided, this is a new item creation request.
           const existingItem = originalFormId
             ? catalogItems.find((item) => item.formId === originalFormId)
-            : catalogItems.find((item) => item.formId === formId);
+            : null;
 
-          // Create the item data.
+          // Create the item data with validated inputs.
           const itemData: CatalogItem = {
             formId,
-            category: formData.get("category") as string,
-            description: formData.get("description") as string,
-            size: formData.get("size") as string,
-            paper: formData.get("paper") as string,
-            color: formData.get("color") as string,
-            sides: formData.get("sides") as string,
-            unit: formData.get("unit") as string,
+            category,
+            description,
+            size,
+            paper,
+            color,
+            sides,
+            unit,
             previews: existingItem ? existingItem.previews : [], // Keep existing previews or empty for new items.
           };
 
           let success: boolean;
           if (existingItem) {
             if (originalFormId && originalFormId !== formId) {
-              // The formId has changed, so delete the old item and create a new one.
-              const deleteSuccess = await catalogService.deleteItem(
-                originalFormId,
+              // The formId has changed, so we need to handle this carefully to avoid data loss.
+              // First, check if the new formId already exists.
+              const newItemExists = catalogItems.find((item) =>
+                item.formId === formId
               );
-              if (deleteSuccess) {
-                success = await catalogService.addItem(itemData);
+              if (newItemExists) {
+                success = false; // Cannot change to an existing formId
               } else {
-                success = false;
+                // Safe to proceed: delete old item and create new one.
+                const deleteSuccess = await catalogService.deleteItem(
+                  originalFormId,
+                );
+                if (deleteSuccess) {
+                  success = await catalogService.addItem(itemData);
+                } else {
+                  success = false;
+                }
               }
             } else {
               // Update the existing item with the same formId.
@@ -104,10 +149,13 @@ export function EditPageRoute() {
 
           if (!success) {
             return new Response(
-              <NotFoundPage itemId={formId} />,
+              JSON.stringify({
+                success: false,
+                error: "Failed to save item. Please try again.",
+              }),
               {
-                headers: { "Content-Type": "text/html" },
-                status: 400,
+                headers: { "Content-Type": "application/json" },
+                status: 500,
               },
             );
           }
@@ -140,7 +188,6 @@ export function EditPageRoute() {
             );
           }
 
-          const catalogService = new KvCatalogService(kv);
           const catalogItems = (await catalogService.getItems()) ?? [];
           const item = catalogItems.find((item) => item.formId === formId);
 
@@ -193,7 +240,6 @@ export function EditPageRoute() {
             );
           }
 
-          const catalogService = new KvCatalogService(kv);
           const success = await catalogService.deleteItem(formId);
 
           if (!success) {
@@ -247,22 +293,20 @@ export function EditPage(props: EditPageProps) {
               <TH>Category</TH>
               <TH>Actions</TH>
             </TR>
-            {props.items
-              .map((item) => (
-                <TR>
-                  <TD>
-                    <A href={`/${item.formId}`}>{item.formId}</A>
-                  </TD>
-                  <TD>{item.description}</TD>
-                  <TD>{item.category}</TD>
-                  <TD>
-                    <A href={`/edit/${item.formId}`} class="btn">
-                      Edit
-                    </A>
-                  </TD>
-                </TR>
-              ))
-              .join("")}
+            {props.items.map((item) => (
+              <TR>
+                <TD>
+                  <A href={`/${item.formId}`}>{item.formId}</A>
+                </TD>
+                <TD>{item.description}</TD>
+                <TD>{item.category}</TD>
+                <TD>
+                  <A href={`/edit/${item.formId}`} class="btn">
+                    Edit
+                  </A>
+                </TD>
+              </TR>
+            ))}
           </TBODY>
         </TABLE>
       </DIV>
@@ -527,22 +571,6 @@ async function handleFormSubmit(event) {
     }
   }
   
-  // Submit the form with the password in the Authorization header.
-  const submitForm = document.createElement('form');
-  submitForm.method = 'POST';
-  submitForm.action = '/edit';
-  
-  // Add all the form fields.
-  for (const [key, value] of formData.entries()) {
-    const input = document.createElement('input');
-    input.type = 'hidden';
-    input.name = key;
-    input.value = value;
-    submitForm.appendChild(input);
-  }
-  
-  document.body.appendChild(submitForm);
-  
   // Submit with custom headers using fetch.
   try {
     const response = await fetch('/edit', {
@@ -563,7 +591,6 @@ async function handleFormSubmit(event) {
     alert('An error occurred while submitting the form');
   }
   
-  document.body.removeChild(submitForm);
   return true;
 }
 

--- a/src/routes/edit.tsx
+++ b/src/routes/edit.tsx
@@ -1,0 +1,705 @@
+import { Delete, Get, Post, Router } from "@fartlabs/rtx";
+import {
+  A,
+  BUTTON,
+  DIV,
+  FORM,
+  H1,
+  INPUT,
+  LABEL,
+  P,
+  SCRIPT,
+  TABLE,
+  TBODY,
+  TD,
+  TH,
+  TR,
+} from "@fartlabs/htx";
+import { Layout } from "#/components/layout.tsx";
+import { RedirectPage } from "#/components/redirect.tsx";
+import { NotFoundPage } from "#/components/not-found.tsx";
+import type { CatalogItem } from "#/lib/snfforms.ts";
+import { kv, KvCatalogService } from "#/lib/kv.ts";
+
+export function EditPageRoute() {
+  return (
+    <Router>
+      <Get
+        pattern="/edit"
+        handler={async (_ctx) => {
+          const catalogService = new KvCatalogService(kv);
+          const catalogItems = (await catalogService.getItems()) ?? [];
+
+          return new Response(
+            <EditPage items={catalogItems} />,
+            { headers: { "Content-Type": "text/html" } },
+          );
+        }}
+      />
+
+      <Post
+        pattern="/edit"
+        handler={async (ctx) => {
+          const formData = await ctx.request.formData();
+          const catalogService = new KvCatalogService(kv);
+
+          // Check admin password from Authorization header.
+          const authHeader = ctx.request.headers.get("Authorization");
+          const adminPassword = authHeader?.replace("Bearer ", "");
+          const expectedPassword = Deno.env.get("SECRET_PASSWORD");
+
+          if (!expectedPassword || adminPassword !== expectedPassword) {
+            return new Response(
+              <PasswordErrorPage />,
+              {
+                headers: { "Content-Type": "text/html" },
+                status: 401,
+              },
+            );
+          }
+
+          const formId = formData.get("formId") as string;
+          const catalogItems = (await catalogService.getItems()) ?? [];
+          const existingItem = catalogItems.find((item) =>
+            item.formId === formId
+          );
+
+          // Create the item data.
+          const itemData: CatalogItem = {
+            formId,
+            category: formData.get("category") as string,
+            description: formData.get("description") as string,
+            size: formData.get("size") as string,
+            paper: formData.get("paper") as string,
+            color: formData.get("color") as string,
+            sides: formData.get("sides") as string,
+            unit: formData.get("unit") as string,
+            previews: existingItem ? existingItem.previews : [], // Keep existing previews or empty for new items.
+          };
+
+          let success: boolean;
+          if (existingItem) {
+            // Update existing item.
+            success = await catalogService.updateItem(formId, itemData);
+          } else {
+            // Add new item.
+            success = await catalogService.addItem(itemData);
+          }
+
+          if (!success) {
+            return new Response(
+              <NotFoundPage itemId={formId} />,
+              {
+                headers: { "Content-Type": "text/html" },
+                status: 400,
+              },
+            );
+          }
+
+          return new Response(
+            <RedirectPage redirectUrl="/edit" />,
+            { headers: { "Content-Type": "text/html" } },
+          );
+        }}
+      />
+
+      <Get
+        pattern="/edit/new"
+        handler={(_ctx) => {
+          return new Response(
+            <CreateItemPage />,
+            { headers: { "Content-Type": "text/html" } },
+          );
+        }}
+      />
+
+      <Get
+        pattern="/edit/:formId"
+        handler={async (ctx) => {
+          const formId = ctx.params?.pathname.groups.formId;
+          if (!formId) {
+            return new Response(
+              <RedirectPage redirectUrl="/edit" />,
+              { headers: { "Content-Type": "text/html" } },
+            );
+          }
+
+          const catalogService = new KvCatalogService(kv);
+          const catalogItems = (await catalogService.getItems()) ?? [];
+          const item = catalogItems.find((item) => item.formId === formId);
+
+          if (!item) {
+            return new Response(
+              <NotFoundPage itemId={formId} />,
+              {
+                headers: { "Content-Type": "text/html" },
+                status: 404,
+              },
+            );
+          }
+
+          return new Response(
+            <EditItemPage item={item} />,
+            { headers: { "Content-Type": "text/html" } },
+          );
+        }}
+      />
+
+      <Delete
+        pattern="/edit/:formId"
+        handler={async (ctx) => {
+          const formId = ctx.params?.pathname.groups.formId;
+          if (!formId) {
+            return new Response(
+              JSON.stringify({ success: false, error: "Form ID is required" }),
+              {
+                headers: { "Content-Type": "application/json" },
+                status: 400,
+              },
+            );
+          }
+
+          // Check admin password from Authorization header.
+          const authHeader = ctx.request.headers.get("Authorization");
+          const adminPassword = authHeader?.replace("Bearer ", "");
+          const expectedPassword = Deno.env.get("SECRET_PASSWORD");
+
+          if (!expectedPassword || adminPassword !== expectedPassword) {
+            return new Response(
+              JSON.stringify({
+                success: false,
+                error: "Invalid admin password",
+              }),
+              {
+                headers: { "Content-Type": "application/json" },
+                status: 401,
+              },
+            );
+          }
+
+          const catalogService = new KvCatalogService(kv);
+          const success = await catalogService.deleteItem(formId);
+
+          if (!success) {
+            return new Response(
+              JSON.stringify({ success: false, error: "Item not found" }),
+              {
+                headers: { "Content-Type": "application/json" },
+                status: 404,
+              },
+            );
+          }
+
+          return new Response(
+            JSON.stringify({ success: true }),
+            {
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }}
+      />
+    </Router>
+  );
+}
+
+interface EditPageProps {
+  items: CatalogItem[];
+}
+
+export function EditPage(props: EditPageProps) {
+  return (
+    <Layout
+      title="Edit Catalog Items"
+      description="Edit and manage catalog items"
+    >
+      <DIV class="card">
+        <DIV class="card-header">
+          <H1 class="card-title">Edit Catalog Items</H1>
+          <P class="text-muted mb-0">Manage your catalog items</P>
+          <DIV class="mt-3">
+            <A href="/edit/new" class="btn btn-primary">
+              Create New Form
+            </A>
+          </DIV>
+        </DIV>
+
+        <TABLE>
+          <TBODY>
+            <TR>
+              <TH>Form ID</TH>
+              <TH>Description</TH>
+              <TH>Category</TH>
+              <TH>Actions</TH>
+            </TR>
+            {props.items
+              .map((item) => (
+                <TR>
+                  <TD>{item.formId}</TD>
+                  <TD>{item.description}</TD>
+                  <TD>{item.category}</TD>
+                  <TD>
+                    <A href={`/edit/${item.formId}`} class="btn">
+                      Edit
+                    </A>
+                  </TD>
+                </TR>
+              ))
+              .join("")}
+          </TBODY>
+        </TABLE>
+      </DIV>
+    </Layout>
+  );
+}
+
+interface EditItemPageProps {
+  item: CatalogItem;
+}
+
+const editFormScript = `
+async function handleEditFormSubmit(event) {
+  event.preventDefault();
+  
+  const formData = new FormData(event.target);
+  const formId = formData.get('formId');
+  
+  if (!formId) {
+    alert('Form ID is required');
+    return false;
+  }
+  
+  // Get admin password.
+  const password = prompt('Enter admin password to update this form:');
+  if (!password) {
+    return false;
+  }
+  
+  // Submit the form with password in Authorization header.
+  try {
+    const response = await fetch('/edit', {
+      method: 'POST',
+      headers: {
+        'Authorization': \`Bearer \${password}\`,
+      },
+      body: formData,
+    });
+    
+    if (response.ok) {
+      window.location.href = '/edit';
+    } else {
+      alert('Failed to update form. Please check your password and try again.');
+    }
+  } catch (error) {
+    console.error('Error updating form:', error);
+    alert('An error occurred while updating the form');
+  }
+  
+  return true;
+}
+
+// Add event listener when page loads.
+document.addEventListener('DOMContentLoaded', function() {
+  const form = document.getElementById('edit-form');
+  if (form) {
+    form.addEventListener('submit', handleEditFormSubmit);
+  }
+});
+`;
+
+export function EditItemPage(props: EditItemPageProps) {
+  return (
+    <Layout
+      title={`Edit ${props.item.formId}`}
+      description={`Edit ${props.item.formId} catalog item`}
+      head={<SCRIPT>{deleteItemScript + editFormScript}</SCRIPT>}
+    >
+      <DIV class="card">
+        <DIV class="card-header">
+          <H1 class="card-title">Edit {props.item.formId}</H1>
+          <P class="text-muted mb-0">Update catalog item details</P>
+        </DIV>
+
+        <FORM
+          method="POST"
+          action={`/edit?formId=${props.item.formId}`}
+          id="edit-form"
+        >
+          <DIV class="form-group">
+            <LABEL for="formId">Form ID</LABEL>
+            <INPUT
+              type="text"
+              id="formId"
+              name="formId"
+              value={props.item.formId}
+              required="required"
+            />
+          </DIV>
+
+          <DIV class="form-group">
+            <LABEL for="description">Description</LABEL>
+            <INPUT
+              type="text"
+              id="description"
+              name="description"
+              value={props.item.description}
+              required="required"
+            />
+          </DIV>
+
+          <DIV class="form-group">
+            <LABEL for="category">Category</LABEL>
+            <INPUT
+              type="text"
+              id="category"
+              name="category"
+              value={props.item.category}
+              required="required"
+            />
+          </DIV>
+
+          <DIV class="form-group">
+            <LABEL for="size">Size</LABEL>
+            <INPUT
+              type="text"
+              id="size"
+              name="size"
+              value={props.item.size}
+              required="required"
+            />
+          </DIV>
+
+          <DIV class="form-group">
+            <LABEL for="paper">Paper</LABEL>
+            <INPUT
+              type="text"
+              id="paper"
+              name="paper"
+              value={props.item.paper}
+              required="required"
+            />
+          </DIV>
+
+          <DIV class="form-group">
+            <LABEL for="color">Color</LABEL>
+            <INPUT
+              type="text"
+              id="color"
+              name="color"
+              value={props.item.color}
+              required="required"
+            />
+          </DIV>
+
+          <DIV class="form-group">
+            <LABEL for="sides">Sides</LABEL>
+            <INPUT
+              type="text"
+              id="sides"
+              name="sides"
+              value={props.item.sides}
+              required="required"
+            />
+          </DIV>
+
+          <DIV class="form-group">
+            <LABEL for="unit">Unit</LABEL>
+            <INPUT
+              type="text"
+              id="unit"
+              name="unit"
+              value={props.item.unit}
+              required="required"
+            />
+          </DIV>
+
+          <DIV class="form-actions">
+            <DIV class="btn-group">
+              <BUTTON type="submit" class="btn btn-primary">
+                Update Item
+              </BUTTON>
+              <A href="/edit" class="btn btn-secondary">
+                Cancel
+              </A>
+            </DIV>
+            <BUTTON
+              type="button"
+              class="btn btn-danger"
+              onclick={`if (confirm('Are you sure you want to delete ${props.item.formId}? This action cannot be undone.')) { deleteItem('${props.item.formId}'); }`}
+            >
+              Delete Item
+            </BUTTON>
+          </DIV>
+        </FORM>
+      </DIV>
+    </Layout>
+  );
+}
+
+const deleteItemScript = `
+async function deleteItem(formId) {
+  const password = prompt('Enter admin password to delete this item:');
+  if (!password) {
+    return;
+  }
+
+  try {
+    const response = await fetch(\`/edit/\${formId}\`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': \`Bearer \${password}\`,
+      },
+    });
+    
+    const result = await response.json();
+    
+    if (result.success) {
+      // Redirect to edit page after successful deletion.
+      window.location.href = '/edit';
+    } else {
+      alert('Failed to delete item: ' + (result.error || 'Unknown error'));
+    }
+  } catch (error) {
+    console.error('Error deleting item:', error);
+    alert('An error occurred while deleting the item');
+  }
+}
+`;
+
+const createFormScript = `
+async function checkFormIdExists(formId) {
+  try {
+    const response = await fetch(\`/edit/\${formId}\`);
+    return response.status === 200;
+  } catch (error) {
+    console.error('Error checking form ID:', error);
+    return false;
+  }
+}
+
+async function handleFormSubmit(event) {
+  event.preventDefault();
+  
+  const formData = new FormData(event.target);
+  const formId = formData.get('formId');
+  
+  if (!formId) {
+    alert('Form ID is required');
+    return false;
+  }
+  
+  // Get admin password.
+  const password = prompt('Enter admin password to submit this form:');
+  if (!password) {
+    return false;
+  }
+  
+  // Check if form ID already exists.
+  const exists = await checkFormIdExists(formId);
+  
+  if (exists) {
+    const confirmed = confirm(\`Form ID "\${formId}" already exists. Do you want to update it instead?\`);
+    if (!confirmed) {
+      return false;
+    }
+  } else {
+    const confirmed = confirm(\`Form ID "\${formId}" does not exist. Do you want to create a new form with this ID?\`);
+    if (!confirmed) {
+      return false;
+    }
+  }
+  
+  // Submit the form with password in Authorization header.
+  const submitForm = document.createElement('form');
+  submitForm.method = 'POST';
+  submitForm.action = '/edit';
+  
+  // Add all form fields.
+  for (const [key, value] of formData.entries()) {
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = key;
+    input.value = value;
+    submitForm.appendChild(input);
+  }
+  
+  document.body.appendChild(submitForm);
+  
+  // Submit with custom headers using fetch.
+  try {
+    const response = await fetch('/edit', {
+      method: 'POST',
+      headers: {
+        'Authorization': \`Bearer \${password}\`,
+      },
+      body: formData,
+    });
+    
+    if (response.ok) {
+      window.location.href = '/edit';
+    } else {
+      alert('Failed to submit form. Please check your password and try again.');
+    }
+  } catch (error) {
+    console.error('Error submitting form:', error);
+    alert('An error occurred while submitting the form');
+  }
+  
+  document.body.removeChild(submitForm);
+  return true;
+}
+
+// Add event listener when page loads.
+document.addEventListener('DOMContentLoaded', function() {
+  const form = document.getElementById('create-form');
+  if (form) {
+    form.addEventListener('submit', handleFormSubmit);
+  }
+});
+`;
+
+export function CreateItemPage() {
+  return (
+    <Layout
+      title="Create New Form"
+      description="Create a new catalog item"
+      head={<SCRIPT>{createFormScript}</SCRIPT>}
+    >
+      <DIV class="card">
+        <DIV class="card-header">
+          <H1 class="card-title">Create New Form</H1>
+          <P class="text-muted mb-0">Add a new form to the catalog</P>
+        </DIV>
+
+        <FORM method="POST" action="/edit" id="create-form">
+          <DIV class="form-group">
+            <LABEL for="formId">Form ID</LABEL>
+            <INPUT
+              type="text"
+              id="formId"
+              name="formId"
+              required="required"
+              placeholder="Enter unique form ID"
+            />
+          </DIV>
+
+          <DIV class="form-group">
+            <LABEL for="description">Description</LABEL>
+            <INPUT
+              type="text"
+              id="description"
+              name="description"
+              required="required"
+              placeholder="Enter form description"
+            />
+          </DIV>
+
+          <DIV class="form-group">
+            <LABEL for="category">Category</LABEL>
+            <INPUT
+              type="text"
+              id="category"
+              name="category"
+              required="required"
+              placeholder="Enter category"
+            />
+          </DIV>
+
+          <DIV class="form-group">
+            <LABEL for="size">Size</LABEL>
+            <INPUT
+              type="text"
+              id="size"
+              name="size"
+              required="required"
+              placeholder="Enter size (e.g., 8.5 x 11)"
+            />
+          </DIV>
+
+          <DIV class="form-group">
+            <LABEL for="paper">Paper</LABEL>
+            <INPUT
+              type="text"
+              id="paper"
+              name="paper"
+              required="required"
+              placeholder="Enter paper type"
+            />
+          </DIV>
+
+          <DIV class="form-group">
+            <LABEL for="color">Color</LABEL>
+            <INPUT
+              type="text"
+              id="color"
+              name="color"
+              required="required"
+              placeholder="Enter color"
+            />
+          </DIV>
+
+          <DIV class="form-group">
+            <LABEL for="sides">Sides</LABEL>
+            <INPUT
+              type="text"
+              id="sides"
+              name="sides"
+              required="required"
+              placeholder="Enter sides (e.g., Single, Double)"
+            />
+          </DIV>
+
+          <DIV class="form-group">
+            <LABEL for="unit">Unit</LABEL>
+            <INPUT
+              type="text"
+              id="unit"
+              name="unit"
+              required="required"
+              placeholder="Enter unit (e.g., Each, Pack, Box)"
+            />
+          </DIV>
+
+          <DIV class="form-actions">
+            <DIV class="btn-group">
+              <BUTTON type="submit" class="btn btn-primary">
+                Create Form
+              </BUTTON>
+              <A href="/edit" class="btn btn-secondary">
+                Cancel
+              </A>
+            </DIV>
+          </DIV>
+        </FORM>
+      </DIV>
+    </Layout>
+  );
+}
+
+export function PasswordErrorPage() {
+  return (
+    <Layout
+      title="Access Denied"
+      description="Invalid admin password"
+    >
+      <DIV class="card text-center">
+        <DIV class="card-header">
+          <H1 class="card-title">Access Denied</H1>
+          <P class="text-muted mb-0">Invalid admin password</P>
+        </DIV>
+
+        <DIV class="card-body">
+          <P class="text-muted">
+            The admin password you entered is incorrect. Please try again.
+          </P>
+        </DIV>
+
+        <DIV class="mt-4">
+          <A href="/edit" class="btn btn-primary">
+            Back to Edit Page
+          </A>
+        </DIV>
+      </DIV>
+    </Layout>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,7 +7,7 @@ import type { CatalogItem } from "#/lib/snfforms.ts";
 import { findCatalogItem } from "#/lib/snfforms.ts";
 import { searchCatalog } from "#/lib/orama.ts";
 import { kv, KvCatalogService } from "#/lib/kv.ts";
-import { searchQuerySchema, validateFormData } from "#/lib/validation.ts";
+import { searchQuerySchema } from "#/lib/validation.ts";
 
 const catalogService = new KvCatalogService(kv);
 
@@ -20,16 +20,13 @@ export function IndexPageRoute() {
           const url = new URL(ctx.request.url);
           const rawSearch = url.searchParams.get("search");
 
-          // Validate search query
-          const searchValidation = validateFormData(
-            searchQuerySchema,
-            rawSearch,
-          );
+          // Validate the search query parameter.
+          const searchValidation = searchQuerySchema.safeParse(rawSearch);
           const search = searchValidation.success
             ? searchValidation.data
             : null;
 
-          // Lazy seed: only seed if the KV store is empty
+          // Lazy seed: only seed if the KV store is empty.
           let catalogItems = (await catalogService.getItems()) ?? [];
           if (catalogItems.length === 0) {
             try {
@@ -37,27 +34,29 @@ export function IndexPageRoute() {
               catalogItems = (await catalogService.getItems()) ?? [];
             } catch (error) {
               console.error("Failed to seed catalog:", error);
-              // Continue with empty catalog rather than failing the request
+              // Continue with empty catalog rather than failing the request.
             }
           }
           const orama = await catalogService.getOramaIndex();
           const items = search && orama
-            ? (await searchCatalog(orama, search)).hits.map((result) => {
-              const item = findCatalogItem(
-                catalogItems,
-                result.document.formId,
-              );
-              if (!item) {
-                // If we can't find a catalog item from search results,
-                // this indicates a data inconsistency, but we'll handle it gracefully
-                console.warn(
-                  `Catalog item not found in search results: ${result.document.formId}`,
+            ? (await searchCatalog(orama, search)).hits
+              .map((result) => {
+                const item = findCatalogItem(
+                  catalogItems,
+                  result.document.formId,
                 );
-                return null;
-              }
+                if (!item) {
+                  // If we can't find a catalog item from search results,
+                  // this indicates a data inconsistency, but we'll handle it gracefully.
+                  console.warn(
+                    `Catalog item not found in search results: ${result.document.formId}`,
+                  );
+                  return null;
+                }
 
-              return item;
-            }).filter((item): item is CatalogItem => item !== null)
+                return item;
+              })
+              .filter((item): item is CatalogItem => item !== null)
             : catalogItems;
 
           return new Response(

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -5,11 +5,15 @@ import { RedirectRoute } from "#/components/redirect.tsx";
 import { Catalog, CatalogScript } from "#/components/catalog.tsx";
 import type { CatalogItem } from "#/lib/snfforms.ts";
 import { findCatalogItem } from "#/lib/snfforms.ts";
-import { createOrama, searchCatalog } from "#/lib/orama.ts";
+import { searchCatalog } from "#/lib/orama.ts";
 import { kv, KvCatalogService } from "#/lib/kv.ts";
 
 const catalogService = new KvCatalogService(kv);
-await catalogService.seed();
+// Only seed if the KV store is empty
+const existingItems = await catalogService.getItems();
+if (!existingItems || existingItems.length === 0) {
+  await catalogService.seed();
+}
 
 export function IndexPageRoute() {
   return (
@@ -21,8 +25,8 @@ export function IndexPageRoute() {
           const search = url.searchParams.get("search");
 
           const catalogItems = (await catalogService.getItems()) ?? [];
-          const orama = await createOrama(catalogItems);
-          const items = search
+          const orama = await catalogService.getOramaIndex();
+          const items = search && orama
             ? (await searchCatalog(orama, search)).hits.map((result) => {
               const item = findCatalogItem(
                 catalogItems,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,13 +7,9 @@ import type { CatalogItem } from "#/lib/snfforms.ts";
 import { findCatalogItem } from "#/lib/snfforms.ts";
 import { searchCatalog } from "#/lib/orama.ts";
 import { kv, KvCatalogService } from "#/lib/kv.ts";
+import { searchQuerySchema, validateFormData } from "#/lib/validation.ts";
 
 const catalogService = new KvCatalogService(kv);
-// Only seed if the KV store is empty
-const existingItems = await catalogService.getItems();
-if (!existingItems || existingItems.length === 0) {
-  await catalogService.seed();
-}
 
 export function IndexPageRoute() {
   return (
@@ -22,9 +18,28 @@ export function IndexPageRoute() {
         pattern="/"
         handler={async (ctx) => {
           const url = new URL(ctx.request.url);
-          const search = url.searchParams.get("search");
+          const rawSearch = url.searchParams.get("search");
 
-          const catalogItems = (await catalogService.getItems()) ?? [];
+          // Validate search query
+          const searchValidation = validateFormData(
+            searchQuerySchema,
+            rawSearch,
+          );
+          const search = searchValidation.success
+            ? searchValidation.data
+            : null;
+
+          // Lazy seed: only seed if the KV store is empty
+          let catalogItems = (await catalogService.getItems()) ?? [];
+          if (catalogItems.length === 0) {
+            try {
+              await catalogService.seed();
+              catalogItems = (await catalogService.getItems()) ?? [];
+            } catch (error) {
+              console.error("Failed to seed catalog:", error);
+              // Continue with empty catalog rather than failing the request
+            }
+          }
           const orama = await catalogService.getOramaIndex();
           const items = search && orama
             ? (await searchCatalog(orama, search)).hits.map((result) => {
@@ -46,7 +61,7 @@ export function IndexPageRoute() {
             : catalogItems;
 
           return new Response(
-            <IndexPage search={search} items={items} />,
+            <IndexPage search={search ?? null} items={items} />,
             { headers: { "Content-Type": "text/html" } },
           );
         }}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -4,8 +4,12 @@ import { Layout } from "#/components/layout.tsx";
 import { RedirectRoute } from "#/components/redirect.tsx";
 import { Catalog, CatalogScript } from "#/components/catalog.tsx";
 import type { CatalogItem } from "#/lib/snfforms.ts";
-import { searchCatalog } from "#/lib/orama.ts";
-import { catalogItems, findCatalogItem } from "#/lib/catalog.ts";
+import { findCatalogItem } from "#/lib/snfforms.ts";
+import { createOrama, searchCatalog } from "#/lib/orama.ts";
+import { kv, KvCatalogService } from "#/lib/kv.ts";
+
+const catalogService = new KvCatalogService(kv);
+await catalogService.seed();
 
 export function IndexPageRoute() {
   return (
@@ -15,9 +19,15 @@ export function IndexPageRoute() {
         handler={async (ctx) => {
           const url = new URL(ctx.request.url);
           const search = url.searchParams.get("search");
+
+          const catalogItems = (await catalogService.getItems()) ?? [];
+          const orama = await createOrama(catalogItems);
           const items = search
-            ? (await searchCatalog(search)).hits.map((result) => {
-              const item = findCatalogItem(result.document.formId);
+            ? (await searchCatalog(orama, search)).hits.map((result) => {
+              const item = findCatalogItem(
+                catalogItems,
+                result.document.formId,
+              );
               if (!item) {
                 // If we can't find a catalog item from search results,
                 // this indicates a data inconsistency, but we'll handle it gracefully

--- a/src/routes/item.tsx
+++ b/src/routes/item.tsx
@@ -18,14 +18,15 @@ import { Layout } from "#/components/layout.tsx";
 import { RedirectPage } from "#/components/redirect.tsx";
 import { NotFoundPage } from "#/components/not-found.tsx";
 import type { CatalogItem } from "#/lib/snfforms.ts";
-import { findCatalogItem } from "#/lib/catalog.ts";
+import { findCatalogItem } from "#/lib/snfforms.ts";
+import { kv, KvCatalogService } from "#/lib/kv.ts";
 
 export function CatalogItemPageRoute() {
   return (
     <Router>
       <Get
         pattern="/:itemId([a-zA-Z0-9-]{3,10})"
-        handler={(ctx) => {
+        handler={async (ctx) => {
           const itemId = ctx.params?.pathname.groups.itemId;
           if (!itemId) {
             return new Response(
@@ -34,7 +35,9 @@ export function CatalogItemPageRoute() {
             );
           }
 
-          const item = findCatalogItem(itemId);
+          const catalogService = new KvCatalogService(kv);
+          const catalogItems = (await catalogService.getItems()) ?? [];
+          const item = findCatalogItem(catalogItems, itemId);
           if (!item) {
             return new Response(
               <NotFoundPage itemId={itemId} />,

--- a/src/routes/item.tsx
+++ b/src/routes/item.tsx
@@ -20,6 +20,9 @@ import { NotFoundPage } from "#/components/not-found.tsx";
 import type { CatalogItem } from "#/lib/snfforms.ts";
 import { findCatalogItem } from "#/lib/snfforms.ts";
 import { kv, KvCatalogService } from "#/lib/kv.ts";
+import { formIdParamSchema, validateFormData } from "#/lib/validation.ts";
+
+const catalogService = new KvCatalogService(kv);
 
 export function CatalogItemPageRoute() {
   return (
@@ -35,7 +38,20 @@ export function CatalogItemPageRoute() {
             );
           }
 
-          const catalogService = new KvCatalogService(kv);
+          // Validate formId parameter
+          const validation = validateFormData(formIdParamSchema, {
+            formId: itemId,
+          });
+          if (!validation.success) {
+            return new Response(
+              <NotFoundPage itemId={itemId} />,
+              {
+                headers: { "Content-Type": "text/html" },
+                status: 400,
+              },
+            );
+          }
+
           const catalogItems = (await catalogService.getItems()) ?? [];
           const item = findCatalogItem(catalogItems, itemId);
           if (!item) {

--- a/src/routes/item.tsx
+++ b/src/routes/item.tsx
@@ -20,7 +20,7 @@ import { NotFoundPage } from "#/components/not-found.tsx";
 import type { CatalogItem } from "#/lib/snfforms.ts";
 import { findCatalogItem } from "#/lib/snfforms.ts";
 import { kv, KvCatalogService } from "#/lib/kv.ts";
-import { formIdParamSchema, validateFormData } from "#/lib/validation.ts";
+import { formIdParamSchema } from "#/lib/validation.ts";
 
 const catalogService = new KvCatalogService(kv);
 
@@ -38,8 +38,8 @@ export function CatalogItemPageRoute() {
             );
           }
 
-          // Validate formId parameter
-          const validation = validateFormData(formIdParamSchema, {
+          // Validate the formId parameter.
+          const validation = formIdParamSchema.safeParse({
             formId: itemId,
           });
           if (!validation.success) {
@@ -135,20 +135,22 @@ export function CatalogItemPage(props: CatalogItemPageProps) {
             </DIV>
             <UL class="preview-list">
               {/* deno-lint-ignore jsx-key */}
-              {props.item.previews.map((preview) => {
-                const img = (
-                  <IMG
-                    src={preview.src}
-                    alt={preview.alt || `${props.item.formId} form preview`}
-                    loading="lazy"
-                  />
-                );
-                return (
-                  <LI class="preview-item">
-                    {preview.pdf ? <A href={preview.pdf}>{img}</A> : img}
-                  </LI>
-                );
-              })}
+              {props.item.previews
+                .map((preview) => {
+                  const img = (
+                    <IMG
+                      src={preview.src}
+                      alt={preview.alt || `${props.item.formId} form preview`}
+                      loading="lazy"
+                    />
+                  );
+                  return (
+                    <LI class="preview-item">
+                      {preview.pdf ? <A href={preview.pdf}>{img}</A> : img}
+                    </LI>
+                  );
+                })
+                .join("")}
             </UL>
           </DIV>
         )


### PR DESCRIPTION
### Changes

- Add admin edit UI and CRUD for catalog items: Introduces an `/edit` admin interface for creating, updating, and deleting catalog items with password protection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a KV-backed catalog with password-protected /edit CRUD, a /api/catalog endpoint, and refactors search/index to use Orama built from KV; updates routes and UI/CSS.
> 
> - **Backend/Storage**:
>   - **Deno KV Service**: New `KvCatalogService` in `#/lib/kv.ts` with item CRUD, file blob ops, seed from `public/catalog.json`, and cached Orama index.
>   - **Types/Validation**: Adds `CatalogFileType`, utility find function in `#/lib/snfforms.ts`, and Zod schemas/parsing in `#/lib/validation.ts`.
> - **Search**:
>   - Refactors `#/lib/orama.ts` to create DB from provided items and `searchCatalog(db, term)`; index sourced from KV.
> - **Routes**:
>   - **Admin**: New `/edit`, `/edit/new`, and `/edit/:formId` with POST/DELETE handlers (password via `SECRET_PASSWORD`).
>   - **API**: New `GET /api/catalog` returning items with CORS.
>   - **Catalog Item**: Moved to `src/routes/item.tsx`, validates param, loads item from KV.
>   - **Index**: Seeds KV on first run, validates `search`, searches via Orama index from KV.
>   - App wiring updated in `src/app.tsx` to include `EditPageRoute`, `ApiRoute`, and new item route.
> - **Frontend/UI**:
>   - Catalog cards wrap entire item in link; category links toggle when active; minor preview/link behavior tweaks.
>   - Navbar subtitle changed to "Forms".
> - **Styles** (`public/snf.css`):
>   - Adds form groups, actions, button variants (`.btn-primary`, `.btn-secondary`, `.btn-danger`), utilities, and layout tweaks; adjusts hover selector for `.item-title`.
> - **Dependencies** (`deno.json`):
>   - Adds `@kitsonk/kv-toolbox`, `zod`; bumps `@orama/orama` and `@std/http`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea080eba9788fb52d05789898c5a04fb44fe01ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->