### PR TITLE
Fix fartkit-snfforms-catalog issue 2

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -5,6 +5,7 @@
     "@fartlabs/htx": "jsr:@fartlabs/htx@^0.0.10",
     "@fartlabs/jsonx": "jsr:@fartlabs/jsonx@^0.0.11",
     "@fartlabs/rtx": "jsr:@fartlabs/rtx@^0.0.15",
+    "@kitsonk/kv-toolbox": "jsr:@kitsonk/kv-toolbox@^0.8.0",
     "@orama/orama": "npm:@orama/orama@^3.1.13",
     "@std/http": "jsr:@std/http@^1.0.17"
   },

--- a/public/snf.css
+++ b/public/snf.css
@@ -943,3 +943,199 @@ li {
     border: 1px solid var(--gray-300);
   }
 }
+
+/* File Manager Styles */
+.file-manager {
+  margin-top: 2rem;
+}
+
+.file-upload-section {
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--gray-200);
+}
+
+.upload-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-label, .file-input-label {
+  font-weight: 500;
+  color: var(--gray-700);
+  font-size: 0.875rem;
+}
+
+.file-input {
+  padding: 0.75rem;
+  border: 2px dashed var(--gray-300);
+  border-radius: 0.5rem;
+  background: var(--gray-50);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.file-input:hover {
+  border-color: var(--primary-color);
+  background: var(--white);
+}
+
+.file-input:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(44, 90, 160, 0.1);
+}
+
+.form-select {
+  padding: 0.75rem;
+  border: 1px solid var(--gray-300);
+  border-radius: 0.375rem;
+  background: var(--white);
+  font-size: 0.875rem;
+}
+
+.form-select:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(44, 90, 160, 0.1);
+}
+
+.file-list-section {
+  padding: 1.5rem;
+}
+
+.file-list {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.file-item {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  border: 1px solid var(--gray-200);
+  border-radius: 0.5rem;
+  background: var(--white);
+  transition: all 0.2s ease;
+}
+
+.file-item:hover {
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  transform: translateY(-1px);
+}
+
+.file-preview {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 120px;
+  margin-bottom: 0.75rem;
+  border-radius: 0.375rem;
+  overflow: hidden;
+  background: var(--gray-50);
+}
+
+.file-thumbnail {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: cover;
+  border-radius: 0.375rem;
+}
+
+.file-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 60px;
+  height: 60px;
+  background: var(--danger-color);
+  color: var(--white);
+  border-radius: 0.375rem;
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+
+.pdf-icon {
+  background: var(--danger-color);
+}
+
+.file-info {
+  flex: 1;
+  margin-bottom: 0.75rem;
+}
+
+.file-name {
+  font-weight: 500;
+  color: var(--gray-900);
+  font-size: 0.875rem;
+  margin-bottom: 0.25rem;
+  word-break: break-word;
+}
+
+.file-meta {
+  color: var(--gray-600);
+  font-size: 0.75rem;
+  margin: 0;
+}
+
+.delete-file-btn {
+  align-self: flex-start;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+  background: var(--danger-color);
+  color: var(--white);
+  border: none;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.delete-file-btn:hover {
+  background: #c82333;
+  transform: translateY(-1px);
+}
+
+.alert {
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.alert-success {
+  background: #d4edda;
+  color: #155724;
+  border: 1px solid #c3e6cb;
+}
+
+.alert-error {
+  background: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+}
+
+/* Responsive design for file manager */
+@media (max-width: 768px) {
+  .file-list {
+    grid-template-columns: 1fr;
+  }
+  
+  .upload-form {
+    gap: 0.75rem;
+  }
+  
+  .file-upload-section,
+  .file-list-section {
+    padding: 1rem;
+  }
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,6 +3,7 @@ import { Get, Router } from "@fartlabs/rtx";
 import { IndexPageRoute } from "./routes/index.tsx";
 import { CatalogItemPageRoute } from "./routes/catalog-item/index.tsx";
 import { NotFoundRoute } from "./routes/not-found.tsx";
+import { FileApiRoutes } from "./routes/api/files/index.tsx";
 
 function StaticRoute() {
   return (
@@ -17,6 +18,7 @@ function StaticRoute() {
 export function App() {
   return (
     <Router>
+      <FileApiRoutes />
       <IndexPageRoute />
       <CatalogItemPageRoute />
       <StaticRoute />

--- a/src/components/catalog.tsx
+++ b/src/components/catalog.tsx
@@ -13,6 +13,7 @@ import {
   UL,
 } from "@fartlabs/htx";
 import type { CatalogItem } from "#/lib/snfforms.ts";
+import { getFormFiles } from "#/lib/file-manager.ts";
 
 export const categories = [
   "Activities/Social Services",
@@ -26,6 +27,26 @@ export const categories = [
 export interface CatalogProps {
   search: string | null;
   items: CatalogItem[];
+}
+
+export interface CatalogItemWithFiles extends CatalogItem {
+  uploadedFiles: import("#/lib/file-manager.ts").FileMetadata[];
+}
+
+/**
+ * Load catalog items with their uploaded files
+ */
+export async function loadCatalogItemsWithFiles(items: CatalogItem[]): Promise<CatalogItemWithFiles[]> {
+  const itemsWithFiles = await Promise.all(
+    items.map(async (item) => {
+      const uploadedFiles = await getFormFiles(item.formId);
+      return {
+        ...item,
+        uploadedFiles
+      };
+    })
+  );
+  return itemsWithFiles;
 }
 
 function getThumbnailPath(previewSrc: string): string {
@@ -68,69 +89,7 @@ export function Catalog(props: CatalogProps) {
         ? (
           <UL class="catalog-list">
             {props.items.map((item) => (
-              <LI class="catalog-item">
-                <DIV class="item-content">
-                  <DIV class="item-thumbnails">
-                    {(() => {
-                      const imagePreviews = item.previews.filter((preview) =>
-                        preview.src.match(/\.(jpg|jpeg)$/i)
-                      );
-                      if (imagePreviews.length > 0) {
-                        const preview = imagePreviews[0];
-                        return (
-                          <A href={`/${item.formId}`}>
-                            <IMG
-                              src={getThumbnailPath(preview.src)}
-                              alt={preview.alt}
-                              class="item-thumbnail"
-                              loading="lazy"
-                              width="120"
-                              decoding="async"
-                              fetchpriority="low"
-                            />
-                          </A>
-                        );
-                      } else {
-                        return (
-                          <A href={`/${item.formId}`}>
-                            <DIV class="item-thumbnail placeholder">
-                              <DIV class="placeholder-content">
-                                <SPAN class="placeholder-text">No Preview</SPAN>
-                              </DIV>
-                            </DIV>
-                          </A>
-                        );
-                      }
-                    })()}
-                  </DIV>
-                  <DIV class="item-info">
-                    <A href={`/${item.formId}`} class="item-title">
-                      {item.description}
-                    </A>
-                    <DIV class="item-details">
-                      <DIV class="item-specs">
-                        <SPAN class="spec-item">Category: {item.category}</SPAN>
-                        <SPAN class="spec-item">Size: {item.size}</SPAN>
-                        <SPAN class="spec-item">Paper: {item.paper}</SPAN>
-                        <SPAN class="spec-item">Color: {item.color}</SPAN>
-                        <SPAN class="spec-item">Sides: {item.sides}</SPAN>
-                        <SPAN class="spec-item">Unit: {item.unit}</SPAN>
-                        {item.previews.some((preview) => preview.pdf)
-                          ? (
-                            <SPAN
-                              class="spec-item"
-                              style="cursor: pointer;"
-                              onclick={`location.href = '/${item.formId}#previews'`}
-                            >
-                              PDF: Available
-                            </SPAN>
-                          )
-                          : ""}
-                      </DIV>
-                    </DIV>
-                  </DIV>
-                </DIV>
-              </LI>
+              <CatalogItemWithThumbnail item={item} />
             ))}
           </UL>
         )
@@ -140,6 +99,78 @@ export function Catalog(props: CatalogProps) {
           </P>
         )}
     </SECTION>
+  );
+}
+
+interface CatalogItemWithThumbnailProps {
+  item: CatalogItem;
+}
+
+function CatalogItemWithThumbnail(props: CatalogItemWithThumbnailProps) {
+  return (
+    <LI class="catalog-item">
+      <DIV class="item-content">
+        <DIV class="item-thumbnails">
+          {(() => {
+            const imagePreviews = props.item.previews.filter((preview) =>
+              preview.src.match(/\.(jpg|jpeg)$/i)
+            );
+            if (imagePreviews.length > 0) {
+              const preview = imagePreviews[0];
+              return (
+                <A href={`/${props.item.formId}`}>
+                  <IMG
+                    src={getThumbnailPath(preview.src)}
+                    alt={preview.alt}
+                    class="item-thumbnail"
+                    loading="lazy"
+                    width="120"
+                    decoding="async"
+                    fetchpriority="low"
+                  />
+                </A>
+              );
+            } else {
+              return (
+                <A href={`/${props.item.formId}`}>
+                  <DIV class="item-thumbnail placeholder">
+                    <DIV class="placeholder-content">
+                      <SPAN class="placeholder-text">No Preview</SPAN>
+                    </DIV>
+                  </DIV>
+                </A>
+              );
+            }
+          })()}
+        </DIV>
+        <DIV class="item-info">
+          <A href={`/${props.item.formId}`} class="item-title">
+            {props.item.description}
+          </A>
+          <DIV class="item-details">
+            <DIV class="item-specs">
+              <SPAN class="spec-item">Category: {props.item.category}</SPAN>
+              <SPAN class="spec-item">Size: {props.item.size}</SPAN>
+              <SPAN class="spec-item">Paper: {props.item.paper}</SPAN>
+              <SPAN class="spec-item">Color: {props.item.color}</SPAN>
+              <SPAN class="spec-item">Sides: {props.item.sides}</SPAN>
+              <SPAN class="spec-item">Unit: {props.item.unit}</SPAN>
+              {props.item.previews.some((preview) => preview.pdf)
+                ? (
+                  <SPAN
+                    class="spec-item"
+                    style="cursor: pointer;"
+                    onclick={`location.href = '/${props.item.formId}#previews'`}
+                  >
+                    PDF: Available
+                  </SPAN>
+                )
+                : ""}
+            </DIV>
+          </DIV>
+        </DIV>
+      </DIV>
+    </LI>
   );
 }
 

--- a/src/components/file-manager.tsx
+++ b/src/components/file-manager.tsx
@@ -1,0 +1,258 @@
+import {
+  BUTTON,
+  DIV,
+  FORM,
+  H3,
+  IMG,
+  INPUT,
+  LABEL,
+  P,
+  SCRIPT,
+  SECTION,
+  SPAN,
+  UL,
+  LI,
+  SELECT,
+  OPTION,
+} from "@fartlabs/htx";
+import type { FileMetadata } from "#/lib/file-manager.ts";
+
+export interface FileManagerProps {
+  formId: string;
+  existingFiles: FileMetadata[];
+}
+
+export function FileManager(props: FileManagerProps) {
+  return (
+    <SECTION class="file-manager">
+      <DIV class="card">
+        <DIV class="card-header">
+          <H3 class="card-title">Preview Files</H3>
+          <P class="text-muted mb-0">
+            Upload images or PDFs to preview this form
+          </P>
+        </DIV>
+
+        <DIV class="file-upload-section">
+          <FORM id="file-upload-form" class="upload-form" enctype="multipart/form-data">
+            <INPUT type="hidden" name="formId" value={props.formId} />
+            
+            <DIV class="form-group">
+              <LABEL for="file-input" class="file-input-label">
+                Choose File
+              </LABEL>
+              <INPUT
+                type="file"
+                id="file-input"
+                name="file"
+                accept="image/*,.pdf"
+                class="file-input"
+                required
+              />
+            </DIV>
+
+            <DIV class="form-group">
+              <LABEL for="preview-type" class="form-label">File Type</LABEL>
+              <SELECT id="preview-type" name="previewType" class="form-select">
+                <OPTION value="image">Image Preview</OPTION>
+                <OPTION value="pdf">PDF Document</OPTION>
+              </SELECT>
+            </DIV>
+
+            <BUTTON type="submit" class="btn btn-primary">
+              Upload File
+            </BUTTON>
+          </FORM>
+        </DIV>
+
+        <DIV class="file-list-section">
+          <H3>Current Files</H3>
+          {props.existingFiles.length > 0 ? (
+            <UL class="file-list" id="file-list">
+              {props.existingFiles.map((file) => (
+                <LI class="file-item" data-filename={file.filename}>
+                  <DIV class="file-preview">
+                    {file.previewType === 'image' ? (
+                      <IMG
+                        src={`/api/files/${file.filename}`}
+                        alt={file.originalName}
+                        class="file-thumbnail"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <DIV class="file-icon pdf-icon">
+                        <SPAN>PDF</SPAN>
+                      </DIV>
+                    )}
+                  </DIV>
+                  <DIV class="file-info">
+                    <P class="file-name">{file.originalName}</P>
+                    <P class="file-meta">
+                      {file.previewType} • {(file.size / 1024).toFixed(1)} KB
+                    </P>
+                  </DIV>
+                  <BUTTON
+                    type="button"
+                    class="btn btn-danger btn-sm delete-file-btn"
+                    data-filename={file.filename}
+                  >
+                    Delete
+                  </BUTTON>
+                </LI>
+              ))}
+            </UL>
+          ) : (
+            <P class="text-muted">No files uploaded yet.</P>
+          )}
+        </DIV>
+      </DIV>
+
+      <FileManagerScript />
+    </SECTION>
+  );
+}
+
+export function FileManagerScript() {
+  return <SCRIPT type="module">{fileManagerScript}</SCRIPT>;
+}
+
+const fileManagerScript = `
+class FileManager {
+  constructor() {
+    this.form = document.getElementById('file-upload-form');
+    this.fileList = document.getElementById('file-list');
+    this.fileInput = document.getElementById('file-input');
+    
+    this.init();
+  }
+
+  init() {
+    if (this.form) {
+      this.form.addEventListener('submit', this.handleUpload.bind(this));
+    }
+    
+    // Add delete button listeners
+    document.addEventListener('click', (e) => {
+      if (e.target.classList.contains('delete-file-btn')) {
+        this.handleDelete(e.target.dataset.filename);
+      }
+    });
+  }
+
+  async handleUpload(e) {
+    e.preventDefault();
+    
+    const formData = new FormData(this.form);
+    const submitBtn = this.form.querySelector('button[type="submit"]');
+    
+    // Disable submit button
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Uploading...';
+    
+    try {
+      const response = await fetch('/api/files/upload', {
+        method: 'POST',
+        body: formData
+      });
+      
+      const result = await response.json();
+      
+      if (result.success) {
+        this.addFileToList(result.metadata);
+        this.form.reset();
+        this.showMessage('File uploaded successfully!', 'success');
+      } else {
+        this.showMessage('Upload failed: ' + (result.error || 'Unknown error'), 'error');
+      }
+    } catch (error) {
+      console.error('Upload error:', error);
+      this.showMessage('Upload failed: ' + error.message, 'error');
+    } finally {
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Upload File';
+    }
+  }
+
+  async handleDelete(filename) {
+    if (!confirm('Are you sure you want to delete this file?')) {
+      return;
+    }
+    
+    try {
+      const response = await fetch(`/api/files/${filename}`, {
+        method: 'DELETE'
+      });
+      
+      const result = await response.json();
+      
+      if (result.success) {
+        this.removeFileFromList(filename);
+        this.showMessage('File deleted successfully!', 'success');
+      } else {
+        this.showMessage('Delete failed: ' + (result.error || 'Unknown error'), 'error');
+      }
+    } catch (error) {
+      console.error('Delete error:', error);
+      this.showMessage('Delete failed: ' + error.message, 'error');
+    }
+  }
+
+  addFileToList(metadata) {
+    if (!this.fileList) return;
+    
+    const fileItem = document.createElement('li');
+    fileItem.className = 'file-item';
+    fileItem.dataset.filename = metadata.filename;
+    
+    const preview = metadata.previewType === 'image' 
+      ? `<img src="${metadata.url}" alt="${metadata.originalName}" class="file-thumbnail" loading="lazy">`
+      : `<div class="file-icon pdf-icon"><span>PDF</span></div>`;
+    
+    fileItem.innerHTML = `
+      <div class="file-preview">${preview}</div>
+      <div class="file-info">
+        <p class="file-name">${metadata.originalName}</p>
+        <p class="file-meta">${metadata.previewType} • ${(metadata.size / 1024).toFixed(1)} KB</p>
+      </div>
+      <button type="button" class="btn btn-danger btn-sm delete-file-btn" data-filename="${metadata.filename}">
+        Delete
+      </button>
+    `;
+    
+    this.fileList.appendChild(fileItem);
+  }
+
+  removeFileFromList(filename) {
+    const fileItem = this.fileList?.querySelector(`[data-filename="${filename}"]`);
+    if (fileItem) {
+      fileItem.remove();
+    }
+  }
+
+  showMessage(message, type) {
+    // Create or update message element
+    let messageEl = document.getElementById('file-message');
+    if (!messageEl) {
+      messageEl = document.createElement('div');
+      messageEl.id = 'file-message';
+      messageEl.className = 'alert';
+      document.querySelector('.file-manager').prepend(messageEl);
+    }
+    
+    messageEl.textContent = message;
+    messageEl.className = `alert alert-${type}`;
+    
+    // Auto-hide after 5 seconds
+    setTimeout(() => {
+      if (messageEl) {
+        messageEl.remove();
+      }
+    }, 5000);
+  }
+}
+
+// Initialize when DOM is loaded
+document.addEventListener('DOMContentLoaded', () => {
+  new FileManager();
+});
+`;

--- a/src/lib/file-manager.ts
+++ b/src/lib/file-manager.ts
@@ -1,0 +1,142 @@
+import { createKvStore } from "@kitsonk/kv-toolbox";
+
+// Initialize KV store for file management
+const kv = await Deno.openKv();
+const fileStore = createKvStore(kv, "files");
+
+export interface FileMetadata {
+  formId: string;
+  filename: string;
+  originalName: string;
+  contentType: string;
+  size: number;
+  uploadedAt: string;
+  previewType: 'image' | 'pdf';
+}
+
+/**
+ * Upload a file to KV storage
+ */
+export async function uploadFile(
+  formId: string,
+  file: File,
+  previewType: 'image' | 'pdf' = 'image'
+): Promise<FileMetadata> {
+  const filename = `${formId}_${Date.now()}_${file.name}`;
+  const fileData = new Uint8Array(await file.arrayBuffer());
+  
+  const metadata: FileMetadata = {
+    formId,
+    filename,
+    originalName: file.name,
+    contentType: file.type,
+    size: file.size,
+    uploadedAt: new Date().toISOString(),
+    previewType
+  };
+
+  // Store file data with filename as key
+  await fileStore.set(filename, fileData);
+  
+  // Store metadata with a separate key for easy querying
+  await kv.set([`file_metadata`, filename], metadata);
+  
+  // Store filename in form's file list
+  const formFilesKey = [`form_files`, formId];
+  const existingFiles = await kv.get<string[]>(formFilesKey);
+  const fileList = existingFiles.value || [];
+  fileList.push(filename);
+  await kv.set(formFilesKey, fileList);
+
+  return metadata;
+}
+
+/**
+ * Delete a file from KV storage
+ */
+export async function deleteFile(filename: string): Promise<boolean> {
+  try {
+    // Get metadata first to find formId
+    const metadataKey = [`file_metadata`, filename];
+    const metadataResult = await kv.get<FileMetadata>(metadataKey);
+    
+    if (!metadataResult.value) {
+      return false;
+    }
+
+    const formId = metadataResult.value.formId;
+
+    // Delete file data
+    await fileStore.delete(filename);
+    
+    // Delete metadata
+    await kv.delete(metadataKey);
+    
+    // Remove from form's file list
+    const formFilesKey = [`form_files`, formId];
+    const existingFiles = await kv.get<string[]>(formFilesKey);
+    if (existingFiles.value) {
+      const updatedFileList = existingFiles.value.filter(f => f !== filename);
+      await kv.set(formFilesKey, updatedFileList);
+    }
+
+    return true;
+  } catch (error) {
+    console.error('Error deleting file:', error);
+    return false;
+  }
+}
+
+/**
+ * Get file data from KV storage
+ */
+export async function getFile(filename: string): Promise<Uint8Array | null> {
+  try {
+    return await fileStore.get(filename);
+  } catch (error) {
+    console.error('Error getting file:', error);
+    return null;
+  }
+}
+
+/**
+ * Get file metadata
+ */
+export async function getFileMetadata(filename: string): Promise<FileMetadata | null> {
+  try {
+    const result = await kv.get<FileMetadata>([`file_metadata`, filename]);
+    return result.value;
+  } catch (error) {
+    console.error('Error getting file metadata:', error);
+    return null;
+  }
+}
+
+/**
+ * Get all files for a specific form
+ */
+export async function getFormFiles(formId: string): Promise<FileMetadata[]> {
+  try {
+    const formFilesKey = [`form_files`, formId];
+    const result = await kv.get<string[]>(formFilesKey);
+    
+    if (!result.value) {
+      return [];
+    }
+
+    const metadataPromises = result.value.map(filename => getFileMetadata(filename));
+    const metadataResults = await Promise.all(metadataPromises);
+    
+    return metadataResults.filter((metadata): metadata is FileMetadata => metadata !== null);
+  } catch (error) {
+    console.error('Error getting form files:', error);
+    return [];
+  }
+}
+
+/**
+ * Generate a URL for accessing a file
+ */
+export function getFileUrl(filename: string): string {
+  return `/api/files/${filename}`;
+}

--- a/src/routes/api/files/index.tsx
+++ b/src/routes/api/files/index.tsx
@@ -1,0 +1,101 @@
+import { Get, Post, Delete, Router } from "@fartlabs/rtx";
+import { getFile, getFileMetadata, deleteFile, uploadFile } from "#/lib/file-manager.ts";
+
+export function FileApiRoutes() {
+  return (
+    <Router>
+      {/* Get file by filename */}
+      <Get
+        pattern="/api/files/:filename"
+        handler={async (ctx) => {
+          const filename = ctx.params?.pathname.groups.filename;
+          if (!filename) {
+            return new Response("Filename required", { status: 400 });
+          }
+
+          const fileData = await getFile(filename);
+          if (!fileData) {
+            return new Response("File not found", { status: 404 });
+          }
+
+          const metadata = await getFileMetadata(filename);
+          const contentType = metadata?.contentType || "application/octet-stream";
+
+          return new Response(fileData, {
+            headers: {
+              "Content-Type": contentType,
+              "Content-Disposition": `inline; filename="${metadata?.originalName || filename}"`,
+            },
+          });
+        }}
+      />
+
+      {/* Upload file */}
+      <Post
+        pattern="/api/files/upload"
+        handler={async (ctx) => {
+          try {
+            const formData = await ctx.request.formData();
+            const file = formData.get("file") as File;
+            const formId = formData.get("formId") as string;
+            const previewType = (formData.get("previewType") as string) || "image";
+
+            if (!file || !formId) {
+              return new Response("File and formId are required", { status: 400 });
+            }
+
+            // Validate file type
+            const allowedImageTypes = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
+            const allowedPdfTypes = ["application/pdf"];
+            const allowedTypes = [...allowedImageTypes, ...allowedPdfTypes];
+
+            if (!allowedTypes.includes(file.type)) {
+              return new Response("Invalid file type. Only images and PDFs are allowed.", { status: 400 });
+            }
+
+            // Validate file size (max 10MB)
+            const maxSize = 10 * 1024 * 1024; // 10MB
+            if (file.size > maxSize) {
+              return new Response("File too large. Maximum size is 10MB.", { status: 400 });
+            }
+
+            const metadata = await uploadFile(formId, file, previewType as 'image' | 'pdf');
+
+            return new Response(JSON.stringify({
+              success: true,
+              metadata: {
+                ...metadata,
+                url: `/api/files/${metadata.filename}`
+              }
+            }), {
+              headers: { "Content-Type": "application/json" },
+            });
+          } catch (error) {
+            console.error("Upload error:", error);
+            return new Response("Upload failed", { status: 500 });
+          }
+        }}
+      />
+
+      {/* Delete file */}
+      <Delete
+        pattern="/api/files/:filename"
+        handler={async (ctx) => {
+          const filename = ctx.params?.pathname.groups.filename;
+          if (!filename) {
+            return new Response("Filename required", { status: 400 });
+          }
+
+          const success = await deleteFile(filename);
+          if (!success) {
+            return new Response("File not found or could not be deleted", { status: 404 });
+          }
+
+          return new Response(JSON.stringify({ success: true }), {
+            headers: { "Content-Type": "application/json" },
+          });
+        }}
+      />
+    </Router>
+  );
+}

--- a/src/routes/catalog-item/index.tsx
+++ b/src/routes/catalog-item/index.tsx
@@ -17,15 +17,17 @@ import {
 import { Layout } from "#/components/layout.tsx";
 import { RedirectPage } from "#/components/redirect.tsx";
 import { NotFoundPage } from "#/components/not-found.tsx";
+import { FileManager } from "#/components/file-manager.tsx";
 import type { CatalogItem } from "#/lib/snfforms.ts";
 import { findCatalogItem } from "#/lib/catalog.ts";
+import { getFormFiles } from "#/lib/file-manager.ts";
 
 export function CatalogItemPageRoute() {
   return (
     <Router>
       <Get
         pattern="/:itemId([a-zA-Z0-9-]{3,10})"
-        handler={(ctx) => {
+        handler={async (ctx) => {
           const itemId = ctx.params?.pathname.groups.itemId;
           if (!itemId) {
             return new Response(
@@ -45,8 +47,11 @@ export function CatalogItemPageRoute() {
             );
           }
 
+          // Load uploaded files for this form
+          const uploadedFiles = await getFormFiles(itemId);
+
           return new Response(
-            <CatalogItemPage item={item} />,
+            <CatalogItemPage item={item} uploadedFiles={uploadedFiles} />,
             { headers: { "Content-Type": "text/html" } },
           );
         }}
@@ -57,6 +62,7 @@ export function CatalogItemPageRoute() {
 
 interface CatalogItemPageProps {
   item: CatalogItem;
+  uploadedFiles: import("#/lib/file-manager.ts").FileMetadata[];
 }
 
 export function CatalogItemPage(props: CatalogItemPageProps) {
@@ -134,6 +140,8 @@ export function CatalogItemPage(props: CatalogItemPageProps) {
           </DIV>
         )
         : ""}
+
+      <FileManager formId={props.item.formId} existingFiles={props.uploadedFiles} />
     </Layout>
   );
 }


### PR DESCRIPTION
This pull request contains changes generated by Cursor background composer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a Deno KV–backed file manager with upload/delete endpoints and UI to manage image/PDF previews per form.
> 
> - **Backend/API**:
>   - Add `FileApiRoutes` with `GET /api/files/:filename`, `POST /api/files/upload` (type/size validation), and `DELETE /api/files/:filename`.
>   - Implement KV storage in `#/lib/file-manager.ts` (`uploadFile`, `deleteFile`, `getFile`, `getFileMetadata`, `getFormFiles`, `getFileUrl`) using `@kitsonk/kv-toolbox`.
> - **Frontend/UI**:
>   - Add `#/components/file-manager.tsx` to upload/list/delete preview files; includes client-side script for async actions and inline alerts.
>   - Render `FileManager` on catalog item page; route handler made async to load `uploadedFiles` via `getFormFiles`.
>   - Refactor catalog item rendering into `CatalogItemWithThumbnail` and add `loadCatalogItemsWithFiles` helper.
> - **Styles**:
>   - Add comprehensive file manager CSS (upload form, list, thumbnails, responsive) in `public/snf.css`.
> - **App Wiring**:
>   - Register `FileApiRoutes` in `src/app.tsx`.
> - **Config**:
>   - Add dependency `@kitsonk/kv-toolbox` in `deno.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73dcfe3b728f2feff6b452d9b86914415aa540a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->